### PR TITLE
 Add tasks to initial mysql database backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,26 @@ Requirements
 ------------
 An Ansible installation.
 
+### For MySQL backend
+If you want to use this role to automatic create user and database. You need to
+fulfill these requirements
+
+* You have to prepare root or privilege user that can create database and assign
+permission to user. This privilege user must can connect to the database from
+target machine.
+* Configure **pdns_backends_mysql_credential** variable as describe below.
+
 Role Variables
 --------------
 ### pdns_backends
 A dict that allows you configure the backends, this also installs the correct
 packages for these backends. By default, no backends are installed and PowerDNS
 will be unable to start.
+
+### pdns_backends_mysql_credential
+A dict that allows you to put privilege users to create mysql database and
+assign user privilege to this database. Please read requirements before
+configure this variable
 
 ### pdns_config
 A dict detailing the configuration of PowerDNS. You should not set the following
@@ -87,6 +101,34 @@ with the MySQL backend:
         user: powerdns
         password: P0w3rDn5
         dbname: pdns
+    pdns_repo_provider: 'powerdns'
+    pdns_repo_branch: 'master'
+```
+
+Run the PowerDNS masterbranch from a package from repo.powerdns.com as a master
+with the MySQL backend and with privilege root user to initialize database:
+```
+- hosts: ns2.example.net
+  roles:
+    - role: PowerDNS.pdns
+  vars:
+    pdns_config:
+      master: true
+      slave: false
+      local-address: '192.0.2.77'
+    pdns_backends:
+      gmysql:
+        host: 192.0.2.120
+        port: 3306
+        user: powerdns
+        password: P0w3rDn5
+        dbname: pdns
+    pdns_backends_mysql_credential:
+      gmysql:
+        priv_user: root
+        priv_password: myrootpass
+        priv_host:
+          - "%"
     pdns_repo_provider: 'powerdns'
     pdns_repo_branch: 'master'
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 pdns_installation_type: packages
 pdns_repo_provider: os
-# XXX: stable doesnt work ye
-pdns_repo_branch: stable
+# XXX: stable doesnt work yet
+pdns_repo_branch: master
 
 # The user and group to run as.
 # NOTE: at the moment, we don't create a user as we assume the package creates
@@ -51,6 +51,36 @@ pdns_config: {}
 pdns_backends:
   bind:
     config: '/dev/null'
+
+# MySQL credential to create database per backend
+# You must put only gmysql backend
+#
+# For example:
+# pdns_backends_mysql_credential:
+#   'gmysql:one':
+#     'priv_user': root
+#     'priv_password': my_first_password
+#     'priv_host':
+#       - "localhost"
+#       - "%"
+#   'gmysql:two':
+#     'priv_user': someprivuser
+#     'priv_password': my_second_password
+#     'priv_host':
+#       - "localhost"
+
+# Full path to mysql schema file
+pdns_mysql_schema_file:
+  os: /usr/share/dbconfig-common/data/pdns-backend-mysql/install/mysql
+  powerdns: /usr/share/doc/pdns-backend-mysql/schema.mysql.sql
+
+# Dependencies to initial mysql database
+pdns_debian_mysql_dependencies:
+  - python-mysqldb
+  - mysql-client
+pdns_rhel_mysql_dependencies:
+  - MySQL-python
+  - mysql
 
 # Dependencies to build PowerDNS on different distros
 pdns_debian_dependencies: []

--- a/tasks/database.yml
+++ b/tasks/database.yml
@@ -1,0 +1,72 @@
+---
+- name: Install required packaged to initial mysql database for Debian family OS
+  apt:
+     pkg: "{{ item }}"
+     state: installed
+  when: pdns_backends_mysql_credential is defined and ansible_os_family == "Debian"
+  with_items: "{{ pdns_debian_mysql_dependencies }}"
+  tags:
+    - pdns-mysql-db
+
+- name: Install required packaged to initial mysql database for RedHat family OS
+  yum:
+     pkg: "{{ item }}"
+     state: installed
+  when: pdns_backends_mysql_credential is defined and ansible_os_family == "RedHat"
+  with_items: "{{ pdns_rhel_mysql_dependencies }}"
+  tags:
+    - pdns-mysql-db
+
+- name: Create database for PowerDNS
+  mysql_db:
+    login_user: "{{ item.value.priv_user }}"
+    login_password: "{{ item.value.priv_password }}"
+    login_host: "{{ item.value.host }}"
+    name: "{{ item.value.dbname }}"
+    state: present
+  when: pdns_backends_mysql_credential is defined and item.key.startswith('gmysql')
+  with_dict: "{{ pdns_backends | combine(pdns_backends_mysql_credential|default({}), recursive=True) }}"
+  tags:
+    - pdns-mysql-db
+
+- name: Grant access to the DB for the PowerDNS
+  mysql_user:
+    login_user: "{{ item.0.priv_user }}"
+    login_password: "{{ item.0.priv_password }}"
+    login_host: "{{ item.0.host }}"
+    name: "{{ item.0.user }}"
+    password: "{{ item.0.password }}"
+    host: "{{ item.1 }}"
+    state: present
+    priv: "{{ item.0.dbname }}.*:ALL"
+  when: pdns_backends_mysql_credential is defined
+  with_subelements:
+    - "{{ pdns_backends | combine(pdns_backends_mysql_credential|default({}), recursive=True) }}"
+    - priv_host
+    - skip_missing: yes
+  tags:
+    - pdns-mysql-db
+
+- name: Check if mysql database is empty
+  command: >
+    mysql --user="{{ item.value.user }}" --password="{{ item.value.password }}"
+    --host="{{ item.value.host }}" --batch --skip-column-names
+    --execute="SELECT COUNT(DISTINCT `table_name`) FROM `information_schema`.`columns` WHERE `table_schema` = '{{ item.value.dbname }}'"
+  when: item.key.startswith('gmysql')
+  with_dict: "{{ pdns_backends }}"
+  register: pdns_check_mysql_db
+  tags:
+    - pdns-mysql-db
+
+- name: Import initial mysql schema
+  mysql_db:
+    login_user: "{{ item.item.value.user }}"
+    login_password: "{{ item.item.value.password }}"
+    login_host: "{{ item.item.value.host }}"
+    name: "{{ item.item.value.dbname }}"
+    state: import
+    target: "{{ pdns_mysql_schema_file[pdns_repo_provider] }}"
+  when: item.item.key.startswith('gmysql') and item.stdout == "0"
+  with_items: "{{ pdns_check_mysql_db.results }}"
+  tags:
+    - pdns-mysql-db

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,11 @@
 #    - source
 #    - install
 
+- include: database.yml
+  tags:
+    - db
+    - database
+
 - include: configuration.yml
   tags:
     - conf


### PR DESCRIPTION
I abandoned last pull request and use this one instead.

This pull request will add tasks to initial mysql database backend. It read initial mysql schema file from the package depends on os repo or powerdns repo but I not sure and don't think that it will work on RedHat family OS since I don't have CentOS to check path and test this. Also I add task to check database if it empty or not so it can rerun safety without harming current running database.