### PR TITLE
Adds precedence based var loading, fixes RedHat config dir

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Load Distribution specific variables
+  include_vars: '{{item}}'
+  with_first_found:
+    - files:
+      - '{{ansible_os_family}}.yml'
+      - 'default.yml'
+      paths:
+        - ../vars
+
 - include: install.packages-debian.yml
   when: pdns_installation_type == "packages" and ansible_os_family == "Debian"
   tags:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,1 @@
+pdns_config_dir: '/etc/pdns'


### PR DESCRIPTION
Adds precedence based var file loading and uses it to load RedHat specific var file to fix config dir.

The rpecedence based loading should generally be useful for creating distro/branch specific variable files to override defaults