### PR TITLE
* added centos7 fixes for sqlite3 in tasks/database-sqlite3.yml and t…

### DIFF
--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -3,6 +3,10 @@
   apt: name="sqlite3" state="installed"
   when: ansible_os_family == "Debian"
 
+- name: Install required packages to manipulate sqlite3 databases (Redhat)
+  yum: name="sqlite" state="latest"
+  when: ansible_os_family == "RedHat"
+
 - name: Create and chown directory for gsqlite3 databases
   file:
     name: "{{ '/'.join(item.split('/')[:-1]) }}"
@@ -10,7 +14,7 @@
     owner: "{{ pdns_user }}"
     group: "{{ pdns_group }}"
   with_items: "{{pdns_backends_gsqlite3_databases}}"
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" or ansible_os_family == "RedHat"
 
 - name: Initiate the gsqlite3 database
   shell: "sqlite3 {{ item }} < /usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql"
@@ -20,3 +24,12 @@
     creates: "{{ item }}"
   with_items: "{{pdns_backends_gsqlite3_databases}}"
   when: ansible_os_family == "Debian"
+
+- name: Initiate the gsqlite3 database (Redhat)
+  shell: "sqlite3 {{ item }} < /usr/share/doc/pdns-backend-sqlite-0.0.1357g7541e94/schema.sqlite3.sql"
+  become: true
+  become_user: "{{ pdns_user }}"
+  args:
+    creates: "{{ item }}"
+  with_items: "{{pdns_backends_gsqlite3_databases}}"
+  when: ansible_os_family == "RedHat"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
     - pdns-mysql-db
 
 - include: database-sqlite3.yml
-  when: pdns_backends_sqlite3_databases is defined
+  when: pdns_backends_sqlite3_databases is defined or pdns_backends_gsqlite3_databases is defined
   tags:
     - db
     - database


### PR DESCRIPTION
…asks/main.yml.

* when sqlite is used, the pdns_backends_dicts needs to be updated for centos7 packagename. This is sqlite, not sqlite3:
    pdns_backends_dict: {'gsqlite3': 'pdns-backend-sqlite'}