### PR TITLE
Fix: role currently broke by sqlite3 updates

### DIFF
--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -9,7 +9,7 @@
     state: directory
     owner: "{{ pdns_user }}"
     group: "{{ pdns_group }}"
-  with_items: "{{pdns_backends_gsqlite3_databases}}"
+  with_items: "{{pdns_backends_sqlite3_databases|default([])}}"
   when: ansible_os_family == "Debian"
 
 - name: Initiate the gsqlite3 database
@@ -18,5 +18,5 @@
   become_user: "{{ pdns_user }}"
   args:
     creates: "{{ item }}"
-  with_items: "{{pdns_backends_gsqlite3_databases}}"
+  with_items: "{{pdns_backends_sqlite3_databases|default([])}}"
   when: ansible_os_family == "Debian"

--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -1,6 +1,9 @@
 ---
 - name: Install required packages to manipulate sqlite3 databases
-  apt: name="sqlite3" state="installed"
+  apt: name="{{item}}" state="installed"
+  with_items:
+    - sqlite3
+    - pdns-backend-sqlite3
   when: ansible_os_family == "Debian"
 
 - name: Create and chown directory for gsqlite3 databases


### PR DESCRIPTION
Currently the role is broken/fails even if you don't do defines for sqlite3.  From other pull requests it looks like you're deferring some additional changes for sqlite3, but this is a minimal update that makes things work again.

fix typo with `pdns_backends_gsqlite3_databases` -> `pdns_backends_sqlite3_databases` (no g).  You'd think this condition isn't hit if you don't define sqlite3 stuff since inclusion of this file appears to be blocked from tasks/main.yml using the "when" conditional, but ansible actually just adds those when conditions to the tasks within the included file and still executes them.

Simply correcting the typo isn't enough though since the "when" conditions apply to each item from "with_items".  This means that "with_items" is effectively parsed prior to the when condition.  I therefore default the variable to an empty list.  More info can be found here:
https://github.com/ansible/ansible/issues/15964
