### PR TITLE
Fix Ubuntu Pin: origin repo.powerdns.com

### DIFF
--- a/tasks/inspect-Debian.yml
+++ b/tasks/inspect-Debian.yml
@@ -14,7 +14,7 @@
   set_fact:
     pdns_version: |
       {% if pdns_install_repo != "" %}
-      {{ pdns_version_result.versions | selectattr('repo_name', 'equalto', pdns_install_repo['apt_repo_origin']) | map(attribute='version') | sort(reverse=True) | first }}
+      {{ pdns_version_result.versions | selectattr('repo_site', 'equalto', pdns_install_repo['apt_repo_origin']) | map(attribute='version') | sort(reverse=True) | first }}
       {% else %}
       {{ pdns_version_result.versions | map(attribute='version') | sort(reverse=True) | first }}
       {% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 
 pdns_auth_powerdns_repo_master:
-  apt_repo_origin: "PowerDNS"
+  apt_repo_origin: "repo.powerdns.com"
   apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-auth-master main"
   gpg_key: "http://repo.powerdns.com/CBC8B383-pub.asc"
   gpg_key_id: "D47975F8DAE32700A563E64FFF389421CBC8B383"
@@ -9,7 +9,7 @@ pdns_auth_powerdns_repo_master:
   yum_repo_name: "powerdns-auth"
 
 pdns_auth_powerdns_repo_40:
-  apt_repo_origin: "PowerDNS"
+  apt_repo_origin: "repo.powerdns.com"
   apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-auth-40 main"
   gpg_key: "http://repo.powerdns.com/FD380FBB-pub.asc"
   gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"


### PR DESCRIPTION
Repository priority doesn't work on Ubuntu (Xenial)

Following Ubuntu installation guide at https://repo.powerdns.com/#ubuntu **Pin** should be set to repo site: **repo.powerdns.com**

> And this to '/etc/apt/preferences.d/pdns':
> 
> ```
> Package: pdns-*
> Pin: origin repo.powerdns.com
> Pin-Priority: 600`
> ```
