### PR TITLE
Sort config and run some tasks when needed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,8 @@
 
 - name: Include OS-specific variables
   include_vars: "{{ ansible_os_family }}.yml"
+  tags:
+    - always
 
 - include: "repo-{{ ansible_os_family }}.yml"
   when: pdns_install_repo != ""
@@ -59,3 +61,6 @@
 - name: Force handlers flush
   meta: flush_handlers
   when: pdns_flush_handlers
+  tags:
+    - config
+    - service

--- a/templates/pdns.conf.j2
+++ b/templates/pdns.conf.j2
@@ -1,7 +1,7 @@
 config-dir={{pdns_config_dir}}
 setuid={{ pdns_user }}
 setgid={{ pdns_group }}
-{% for config_item, value in pdns_config.items() %}
+{% for config_item, value in pdns_config.items() | sort() %}
 {% if config_item not in ["config-dir", "launch", "setuid", "setgid"] %}
 {% if value == True %}
 {{config_item}}=yes
@@ -15,10 +15,10 @@ setgid={{ pdns_group }}
 
 launch=
 
-{% for backend in pdns_backends -%}
+{% for backend in pdns_backends | sort() -%}
 launch+={{backend}}
 {% set backend_string = backend | replace(':', '-') %}
-{% for backend_item, value in pdns_backends[backend].items() -%}
+{% for backend_item, value in pdns_backends[backend].items() | sort() -%}
 {% if value == True %}
 {{backend_string}}-{{backend_item}}=yes
 {% elif backend_item == False %}


### PR DESCRIPTION
Sort the config keys so position changes in the yaml dict will not trigger a rewrite.

Also run some tasks when actually invoking ansible-playbook with the -t option (so some things don't fail).