### PR TITLE
Make permissions stricter

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,11 +6,15 @@
     state: directory
     owner: "root"
     group: "root"
+    mode: 0750
 
 - name: Generate the PowerDNS configuration
   template:
     src: pdns.conf.j2
     dest: "{{ pdns_config_dir }}/{{ pdns_config_file }}"
+    owner: "root"
+    group: "root"
+    mode: 0640
   notify: Restart PowerDNS
 
 - name: Ensure that the include-dir configuration directory exists
@@ -19,4 +23,5 @@
     state: directory
     owner: root
     group: root
+    mode: 0750
   when: "pdns_config['include-dir'] is defined"

--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -6,6 +6,7 @@
     owner: "{{ pdns_user }}"
     group: "{{ pdns_group }}"
     state: directory
+    mode: 0750
   with_items: "{{ pdns_sqlite_databases_locations }}"
 
 - name: Initiate the SQLite databases on RedHat < 7
@@ -34,5 +35,6 @@
     name: "{{ item }}"
     owner: "{{ pdns_user }}"
     group: "{{ pdns_group }}"
+    mode: 0640
     state: file
   with_items: "{{ pdns_sqlite_databases_locations }}"

--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -28,3 +28,6 @@
   template:
     src: pdns.pin.j2
     dest: /etc/apt/preferences.d/pdns
+    owner: root
+    group: root
+    mode: 0644


### PR DESCRIPTION
To prevent leaking database passwords (in the case of the config) or DNSSEC cryptokeys (in the case of the sqlite database).