### PR TITLE
Allow to manage systemd overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ NEW FEATURES:
 - Allow to manage systemd overrides ([\#53](https://github.com/PowerDNS/pdns-ansible/pull/53))
 
 IMPROVEMENTS:
+
+- Stricter `pdns_config_dir` and `pdns_config['include-dir']` folders permissions ([\#53](https://github.com/PowerDNS/pdns-ansible/pull/53))
 - Improved documentation ([\#52](https://github.com/PowerDNS/pdns-ansible/pull/52))
 - Upgrade molecule to 2.14.0 ([\#51](https://github.com/PowerDNS/pdns-ansible/pull/51))
 - Improved systemd support in the tests ([\#49](https://github.com/PowerDNS/pdns-ansible/pull/49))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## v1.3.0 (To be released)
 
+NEW FEATURES:
+- Allow to manage systemd overrides ([\#53](https://github.com/PowerDNS/pdns-ansible/pull/53))
+
 IMPROVEMENTS:
-- Upgrade molecule to 2.14.0 ([\#51](https://github.com/PowerDNS/pdns-ansible/pull/51))
 - Improved documentation ([\#52](https://github.com/PowerDNS/pdns-ansible/pull/52))
+- Upgrade molecule to 2.14.0 ([\#51](https://github.com/PowerDNS/pdns-ansible/pull/51))
 - Improved systemd support in the tests ([\#49](https://github.com/PowerDNS/pdns-ansible/pull/49))
 
 ## v1.2.1 (2018-04-06)
@@ -12,12 +15,12 @@ BUG FIXES:
 
 ## v1.2.0 (2018-04-05)
 
+NEW FEATURES:
+- Debug packages installation ([\#47](https://github.com/PowerDNS/pdns-ansible/pull/47))
+
 IMPROVEMENTS:
 - Improved test-suite ([\#47](https://github.com/PowerDNS/pdns-ansible/pull/47))
 - Improved config files permissions ([\#45](https://github.com/PowerDNS/pdns-ansible/pull/45))
-
-NEW FEATURES:
-- Debug packages installation ([\#47](https://github.com/PowerDNS/pdns-ansible/pull/47))
 
 ## v1.1.0 (2017-11-25)
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ pdns_config:
 configures PowerDNS Authoritative Server to listen incoming DNS requests on port 5300.
 
 ```yaml
+pdns_service_overrides: {}
+```
+
+Dict with overrides for the service (systemd only).
+This can be used to change any systemd settings in the `[Service]` category
+
+```yaml
 pdns_backends:
   bind:
     config: '/dev/null'

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ pdns_service_overrides: {}
 ```
 
 Dict with overrides for the service (systemd only).
-This can be used to change any systemd settings in the `[Service]` category
+This can be used to change any systemd settings in the `[Service]` category.
 
 ```yaml
 pdns_backends:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,26 +76,30 @@ pdns_flush_handlers: False
 pdns_config_dir: "{{ default_pdns_config_dir }}"
 pdns_config_file: "pdns.conf"
 
-# Dictionary of packages that should be installed to enable the backends.
-# backendname: packagename
-pdns_backends_packages: "{{ default_pdns_backends_packages }}"
-
-# pdns_config: A dict containing all configuration options, except for backend
+# Ddict containing all configuration options, except for backend
 # configuration and the "config-dir", "setuid" and "setgid" directives.
-#
-# Example:
+pdns_config: {}
 # pdns_config:
 #  master: yes
 #  slave: no
 #  local-address: '192.0.2.53'
 #  local-ipv6: '2001:DB8:1::53'
 #  local-port: '5300'
-pdns_config: {}
 
-# pdns_backends: A dict with all the backends you'd like to configure. You can use
-# the multiple backends of the same kind by using {backend}:{instance_name}.
-#
-# For example:
+# Dict with overrides for the service (systemd only)
+pdns_service_overrides: {}
+# pdns_service_overrides:
+#   LimitNOFILE: 10000
+
+# Dictionary of packages that should be installed to enable the backends.
+# backendname: packagename
+pdns_backends_packages: "{{ default_pdns_backends_packages }}"
+
+# A dict with all the backends you'd like to configure.
+# This default starts just the bind-backend with an empty config file
+pdns_backends:
+  bind:
+    config: '/dev/null'
 # pdns_backends:
 #   'gmysql:one':
 #     'user': root
@@ -112,14 +116,9 @@ pdns_config: {}
 #     'config': '/etc/named/named.conf'
 #     'hybrid':  yes
 #     'dnssec-db': '{{ pdns_config_dir }}/dnssec.db'
-#
-# This default starts just the bind-backend with an empty config file
-pdns_backends:
-  bind:
-    config: '/dev/null'
 
 # Administrative credentials to create the PowerDNS Authoritative Server MySQL backend database and user.
-# For example:
+pdns_mysql_databases_credentials: {}
 # pdns_mysql_databases_credentials:
 #   'gmysql:one':
 #     'priv_user': root
@@ -132,7 +131,6 @@ pdns_backends:
 #     'priv_password': my_second_password
 #     'priv_host':
 #       - "localhost"
-pdns_mysql_databases_credentials: {}
 
 # This will create the PowerDNS Authoritative Server backend SQLite database
 # in the given locations.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,4 +9,4 @@
 
 - name: reload systemd and restart PowerDNS
   command: systemctl daemon-reload
-  notify: restart PowerDNS Recursor
+  notify: restart PowerDNS

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,12 @@
 ---
 
-- name: Restart PowerDNS
+- name: restart PowerDNS
   service:
     name: "{{ pdns_service_name }}"
     state: restarted
     sleep: 1  # the sleep is needed to make sure the service has been
     # correctly started after being stopped during restarts
+
+- name: reload systemd and restart PowerDNS
+  command: systemctl daemon-reload
+  notify: restart PowerDNS Recursor

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,3 +29,5 @@ galaxy_info:
     - pdns
     - powerdns
     - pdns-auth
+
+dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,7 @@ galaxy_info:
         - vivid
         - wily
         - xenial
+        - bionic
   galaxy_tags:
     - system
     - dns

--- a/molecule/pdns-41/molecule.yml
+++ b/molecule/pdns-41/molecule.yml
@@ -32,6 +32,11 @@ platforms:
     groups:
       - pdns
 
+  - name: ubuntu-1804
+    image: ubuntu:18.04
+    groups:
+      - pdns
+
   - name: debian-8
     image: debian:8
     groups:
@@ -64,6 +69,9 @@ provisioner:
     prepare: ../resources/prepare.yml
   lint:
     name: ansible-lint
+    options:
+      # excludes "systemctl used in place of systemd module"
+      x: ["ANSIBLE0006"]
 
 lint:
   name: yamllint

--- a/molecule/pdns-41/molecule.yml
+++ b/molecule/pdns-41/molecule.yml
@@ -29,11 +29,13 @@ platforms:
 
   - name: ubuntu-1710
     image: ubuntu:17.10
+    dockerfile_tpl: debian-systemd
     groups:
       - pdns
 
   - name: ubuntu-1804
     image: ubuntu:18.04
+    dockerfile_tpl: debian-systemd
     groups:
       - pdns
 
@@ -44,6 +46,7 @@ platforms:
 
   - name: debian-9
     image: debian:9
+    dockerfile_tpl: debian-systemd
     groups:
       - pdns
 

--- a/molecule/pdns-master/molecule.yml
+++ b/molecule/pdns-master/molecule.yml
@@ -32,6 +32,11 @@ platforms:
     groups:
       - pdns
 
+  - name: ubuntu-1804
+    image: ubuntu:18.04
+    groups:
+      - pdns
+
   - name: debian-8
     image: debian:8
     groups:
@@ -64,6 +69,9 @@ provisioner:
     prepare: ../resources/prepare.yml
   lint:
     name: ansible-lint
+    options:
+      # excludes "systemctl used in place of systemd module"
+      x: ["ANSIBLE0006"]
 
 lint:
   name: yamllint

--- a/molecule/pdns-master/molecule.yml
+++ b/molecule/pdns-master/molecule.yml
@@ -29,11 +29,13 @@ platforms:
 
   - name: ubuntu-1710
     image: ubuntu:17.10
+    dockerfile_tpl: debian-systemd
     groups:
       - pdns
 
   - name: ubuntu-1804
     image: ubuntu:18.04
+    dockerfile_tpl: debian-systemd
     groups:
       - pdns
 
@@ -44,6 +46,7 @@ platforms:
 
   - name: debian-9
     image: debian:9
+    dockerfile_tpl: debian-systemd
     groups:
       - pdns
 

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -3,14 +3,20 @@
 - name: Prepare the Molecule Test Resources
   hosts: pdns
   tasks:
-    # This is required to be sure yum install the
-    # default MySQL and SQLite schemas in /usr/share/doc/
+    # Make sure the default MySQL and SQLite
+    # schemas are installed in /usr/share/doc/
     - name: Disable the YUM 'nodocs' option
       lineinfile:
         line: tsflags=nodocs
         dest: /etc/yum.conf
         state: absent
       when: ansible_pkg_mgr == 'yum'
+
+    - name: Disable the APT 'nodoc' option
+      lineinfile:
+        line: path-exclude=/usr/share/doc/*
+        dest: /etc/dpkg/dpkg.cfg.d/excludes
+        state: absent
 
     # Install rsyslog to capture the PDNS log messages
     # when the service is not managed by systemd

--- a/molecule/resources/tests/all/test_common.py
+++ b/molecule/resources/tests/all/test_common.py
@@ -33,3 +33,15 @@ def test_service(host):
     s = host.ansible('service', 'name=pdns state=started enabled=yes')
 
     assert s["changed"] is False
+
+
+def systemd_override(host):
+    smgr = host.ansible("setup")["ansible_facts"]["ansible_service_mgr"]
+    if smgr == 'systemd':
+        fname = '/etc/systemd/system/pdns.service.d/override.conf'
+        f = host.file(fname)
+
+        assert f.exists
+        assert f.user == 'root'
+        assert f.group == 'root'
+        assert 'LimitCORE=infinity' in f.content

--- a/molecule/resources/vars/pdns-common.yml
+++ b/molecule/resources/vars/pdns-common.yml
@@ -21,3 +21,6 @@ pdns_config:
   webserver: yes
   webserver-address: "0.0.0.0"
   webserver-port: "8001"
+
+pdns_service_overrides:
+  LimitCORE: infinity

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,12 +1,32 @@
 ---
 
+- block:
+
+  - name: Ensure the override directory exists (systemd)
+    file:
+      name: "/etc/systemd/system/{{ pdns_service_name }}.service.d"
+      state: directory
+      owner: root
+      group: root
+
+  - name: Override the PowerDNS Authoritative Server unit (systemd)
+    template:
+      src: "override-service.systemd.conf.j2"
+      dest: "/etc/systemd/system/{{ pdns_service_name }}.service.d/override.conf"
+      owner: root
+      group: root
+    notify: reload systemd and restart PowerDNS
+
+  when: pdns_service_overrides != {}
+    and ansible_service_mgr == "systemd"
+
 - name: Ensure that the PowerDNS Authoritative Server configuration directory exists
   file:
     name: "{{ pdns_config_dir }}"
     state: directory
     owner: "root"
     group: "root"
-    mode: 0755
+    mode: 0750
 
 - name: Generate the PowerDNS Authoritative Server configuration
   template:
@@ -15,7 +35,7 @@
     owner: "root"
     group: "root"
     mode: 0640
-  notify: Restart PowerDNS
+  notify: restart PowerDNS
 
 - name: Ensure that the PowerDNS Authoritative Server 'include-dir' directory exists
   file:
@@ -23,5 +43,5 @@
     state: directory
     owner: "root"
     group: "root"
-    mode: 0755
+    mode: 0750
   when: "pdns_config['include-dir'] is defined"

--- a/templates/override-service.systemd.conf.j2
+++ b/templates/override-service.systemd.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+{% for k, v in pdns_service_overrides.items() %}
+{{ k }}={{ v }}
+{% endfor %}


### PR DESCRIPTION
This PR 
- implements a new option to configure systemd overrides (e.g. to enable coredumps).
- extends the test suite to Bionic
- fix some minor files permissions issues