### PR TITLE
Allow to optionally disable handlers execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+## v1.3.1 (Unreleased)
+
+NEW FEATURES:
+- Add an option (`pdns_disable_handlers`) to disable the automated restart of the service on configuration changes ([\#54](https://github.com/PowerDNS/pdns-ansible/pull/54))
+
 ## v1.3.0 (2018-07-13)
 
 NEW FEATURES:
 - Allow to manage systemd overrides ([\#53](https://github.com/PowerDNS/pdns-ansible/pull/53))
 
 IMPROVEMENTS:
-
 - Stricter `pdns_config_dir` and `pdns_config['include-dir']` folders permissions ([\#53](https://github.com/PowerDNS/pdns-ansible/pull/53))
 - Improved documentation ([\#52](https://github.com/PowerDNS/pdns-ansible/pull/52))
 - Upgrade molecule to 2.14.0 ([\#51](https://github.com/PowerDNS/pdns-ansible/pull/51))

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Force the execution of the handlers at the end of the role. <br />
 See PowerDNS Authoritative Server virtual hosting https://doc.powerdns.com/md/authoritative/running/#starting-virtual-instances-with-system.
 
 ```yaml
+pdns_disable_handlers: False
+```
+
+Disable automated service restart on configuration changes.
+
+```yaml
 pdns_config_dir: "{{ default_pdns_config_dir }}"
 pdns_config_file: "pdns.conf"
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,9 @@ pdns_service_name: "pdns"
 # See PowerDNS Authoritative Server virtual hosting https://doc.powerdns.com/md/authoritative/running/#starting-virtual-instances-with-system.
 pdns_flush_handlers: False
 
+# When True, disable the automated restart of the PowerDNS service
+pdns_disable_handlers: False
+
 # PowerDNS Authoritative Server configuration file and directory
 pdns_config_dir: "{{ default_pdns_config_dir }}"
 pdns_config_file: "pdns.conf"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,9 +4,10 @@
   service:
     name: "{{ pdns_service_name }}"
     state: restarted
-    sleep: 1  # the sleep is needed to make sure the service has been
-    # correctly started after being stopped during restarts
+    sleep: 1                       # the sleep is needed to make sure the service has been
+  when: not pdns_disable_handlers  # correctly started after being stopped during restarts
 
 - name: reload systemd and restart PowerDNS
   command: systemctl daemon-reload
   notify: restart PowerDNS
+  when: not pdns_disable_handlers


### PR DESCRIPTION
This PR adds the `pdns_disable_handlers` variable to optionally disable handlers execution on configuration changes.