### PR TITLE
Fix handler lint issue

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,12 @@
 ---
 
-- name: restart PowerDNS
+- name: Restart PowerDNS
   service:
     name: "{{ pdns_service_name }}"
     state: restarted
-    sleep: 1                       # the sleep is needed to make sure the service has been
-  when: not pdns_disable_handlers  # correctly started after being stopped during restarts
-
-- name: reload systemd and restart PowerDNS
-  command: systemctl daemon-reload
-  notify: restart PowerDNS
-  when: not pdns_disable_handlers
+    daemon_reload: "{{ (ansible_service_mgr == 'systemd') | ternary(true, omit) }}"
+    # the sleep is needed to make sure the service has been
+    # correctly started after being stopped during restarts
+    sleep: 1
+  when:
+    - not pdns_disable_handlers

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,7 +15,7 @@
       dest: "/etc/systemd/system/{{ pdns_service_name }}.service.d/override.conf"
       owner: root
       group: root
-    notify: reload systemd and restart PowerDNS
+    notify: Restart PowerDNS
 
   when: pdns_service_overrides != {}
     and ansible_service_mgr == "systemd"
@@ -35,7 +35,7 @@
     owner: "root"
     group: "root"
     mode: 0640
-  notify: restart PowerDNS
+  notify: Restart PowerDNS
 
 - name: Ensure that the PowerDNS Authoritative Server 'include-dir' directory exists
   file:


### PR DESCRIPTION
Currently a minor lint rule is violated by the handler task, and using
the service module this extra command task is also unnecessary.

The lint error is:
ANSIBLE0006 systemctl used in place of systemd module
Task/Handler: reload systemd and restart PowerDNS