### PR TITLE
Disable rights change for pdns config dir

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -24,9 +24,6 @@
   file:
     name: "{{ pdns_config_dir }}"
     state: directory
-    owner: "root"
-    group: "root"
-    mode: 0750
 
 - name: Generate the PowerDNS Authoritative Server configuration
   template:


### PR DESCRIPTION
Do not touch right for powerdns config and leave it as in package. Because of 750 (default is 755) I unable to place additional configuration files in config directory.