### PR TITLE
Update configure.yml to avoid errors at service startup

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -26,14 +26,14 @@
     state: directory
     owner: "root"
     group: "root"
-    mode: 0750
+    mode: 0755
 
 - name: Generate the PowerDNS Authoritative Server configuration
   template:
     src: pdns.conf.j2
     dest: "{{ pdns_config_dir }}/{{ pdns_config_file }}"
     owner: "root"
-    group: "root"
+    group: "{{ pdns_group }}"
     mode: 0640
   notify: restart PowerDNS
 


### PR DESCRIPTION
- Changed conf dir mode and conf file group to avoid errors on service start
-  Tested with EPEL rpm package, but upstream package should behave the same