### PR TITLE
Fixing multiple Ansible Lint findings

### DIFF
--- a/tasks/database-mysql.yml
+++ b/tasks/database-mysql.yml
@@ -69,12 +69,12 @@
 - name: Define the PowerDNS Authoritative Server database MySQL schema file path on Debian
   set_fact:
     _pdns_mysql_schema_file: "/usr/share/dbconfig-common/data/pdns-backend-mysql/install/mysql"
-  when: ansible_os_family == 'Debian' and pdns_install_repo == ''
+  when: "ansible_os_family == 'Debian' and pdns_install_repo | length == 0"
 
 - name: Define the PowerDNS Authoritative Server database MySQL schema file path on Debian
   set_fact:
     _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql/schema.mysql.sql"
-  when: ansible_os_family == 'Debian' and pdns_install_repo != ''
+  when: "ansible_os_family == 'Debian' and pdns_install_repo | length > 0"
 
 - name: Import the PowerDNS Authoritative Server MySQL schema
   mysql_db:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,7 +12,7 @@
       _pdns_package_version: "={{ pdns_package_version }}"
     when: ansible_os_family == 'Debian'
 
-  when: pdns_package_version != ''
+  when: "pdns_package_version | length > 0"
 
 - name: Install the PowerDNS Authoritative Server
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
     - always
 
 - include: "repo-{{ ansible_os_family }}.yml"
-  when: pdns_install_repo != ""
+  when: "pdns_install_repo | length > 0"
   tags:
     - install
     - repository

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -30,7 +30,7 @@
     baseurl: "{{ pdns_install_repo['yum_repo_baseurl'] }}"
     gpgkey: "{{ pdns_install_repo['gpg_key'] }}"
     gpgcheck: yes
-    priority: 90
+    priority: "90"
     state: present
 
 - name: Add the PowerDNS Authoritative Server debug symbols YUM Repository

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -41,6 +41,6 @@
     baseurl: "{{ pdns_install_repo['yum_debug_symbols_repo_baseurl'] }}"
     gpgkey: "{{ pdns_install_repo['gpg_key'] }}"
     gpgcheck: yes
-    priority: 90
+    priority: "90"
     state: present
   when: pdns_install_debug_symbols_package


### PR DESCRIPTION
While discovering the CI-part of this role I applied some easy fixes to make Ansible less noisy during deployment and let Ansible Lint generate less findings.