### PR TITLE
Newer ansible versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-
 language: python
 python: 2.7
 
@@ -19,7 +18,6 @@ env:
     - ANSIBLE=2.5
     - ANSIBLE=2.6
     - ANSIBLE=2.7
-    - ANSIBLE=2.8
 
 # Install tox
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
     - ANSIBLE=2.3
     - ANSIBLE=2.4
     - ANSIBLE=2.5
+    - ANSIBLE=2.6
+    - ANSIBLE=2.7
+    - ANSIBLE=2.8
 
 # Install tox
 install:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-molecule==2.20.2
+molecule==2.14.0
 docker-py==1.10.6

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-molecule==2.14.0
+molecule==2.22.0
 docker-py==1.10.6

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-molecule==2.22.0
+molecule==2.20.2
 docker-py==1.10.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = py{27}-ansible{22,23,24,25}
+envlist = py{27}-ansible{22,23,24,25,26,27,28}
 skipsdist = true
 
 [travis:env]
@@ -9,6 +9,9 @@ ANSIBLE=
   2.3: ansible23
   2.4: ansible24
   2.5: ansible25
+  2.6: ansible26
+  2.7: ansible27
+  2.8: ansible28
 
 [testenv]
 passenv = *
@@ -18,5 +21,8 @@ deps =
     ansible23: ansible<2.4
     ansible24: ansible<2.5
     ansible25: ansible<2.6
+    ansible26: ansible<2.7
+    ansible27: ansible<2.8
+    ansible28: ansible<2.9
 commands =
     {posargs:molecule test --all --destroy always}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = py{27}-ansible{22,23,24,25,26,27,28}
+envlist = py{27}-ansible{22,23,24,25,26,27}
 skipsdist = true
 
 [travis:env]
@@ -11,7 +11,6 @@ ANSIBLE=
   2.5: ansible25
   2.6: ansible26
   2.7: ansible27
-  2.8: ansible28
 
 [testenv]
 passenv = *
@@ -23,6 +22,5 @@ deps =
     ansible25: ansible<2.6
     ansible26: ansible<2.7
     ansible27: ansible<2.8
-    ansible28: ansible<2.9
 commands =
     {posargs:molecule test --all --destroy always}


### PR DESCRIPTION
Adding Ansible 2.6 and 2.7 to validate role. Ansible 2.8 is still out of scope as it breaks the used Molecule version (2.14). Molecule 2.20+ is required for this, but also more updates changes to the current setup.