### PR TITLE
Add support to the Auth 4.3 and fix some SQLite and permissions issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### Ansible ###
 *.retry
+.ansible_cache
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: python
-python: 2.7
+python:
+  - "2.7"
+  - "3.6"
 
 sudo: required
 
@@ -8,16 +10,20 @@ sudo: required
 services:
   - docker
 
+# Replace aufs with the vfs docker storage driver
+# to prevent systemd to fail starting docker in docker.
+before_install:
+  - sudo sed -i 's|DOCKER_OPTS=.*|DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock --storage-driver vfs"|g' /etc/default/docker
+  - sudo service docker restart
+  - docker info
+
 # Parallel testing of the supported
 # Ansible versions
 env:
   matrix:
-    - ANSIBLE=2.2
-    - ANSIBLE=2.3
-    - ANSIBLE=2.4
-    - ANSIBLE=2.5
-    - ANSIBLE=2.6
     - ANSIBLE=2.7
+    - ANSIBLE=2.8
+    - ANSIBLE=2.9
 
 # Install tox
 install:
@@ -25,7 +31,7 @@ install:
 
 # Test the current PowerDNS Authoritative Server stable release
 script:
-  - tox -- molecule test -s pdns-41
+  - tox -- molecule test -s pdns-42
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ To test all the scenarios run
 
 To run a custom molecule command
 
-    $ tox -e py27-ansible22 -- molecule test -s pdns-41
+    $ tox -e py27-ansible22 -- molecule test -s pdns-42
 
 ## License
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,6 +28,6 @@ galaxy_info:
     - dns
     - pdns
     - powerdns
-    - pdns-auth
+    - auth
 
 dependencies: []

--- a/molecule/pdns-42/molecule.yml
+++ b/molecule/pdns-42/molecule.yml
@@ -1,7 +1,7 @@
 ---
 
 scenario:
-  name: pdns-41
+  name: pdns-42
 
 driver:
   name: docker
@@ -11,38 +11,35 @@ dependency:
 
 platforms:
   - name: centos-6
+    groups: ["pdns"]
     image: centos:6
-    groups:
-      - pdns
 
   - name: centos-7
+    groups: ["pdns"]
     image: centos:7
     dockerfile_tpl: centos-systemd
-    groups:
-      - pdns
 
-  - name: ubuntu-1604
-    image: ubuntu:16.04
-    dockerfile_tpl: debian-systemd
-    groups:
-      - pdns
+  # Temporarely disable CentOS 8 due to:
+  # https://github.com/ansible/ansible/issues/64963
+  # - name: centos-8
+  #   groups: ["pdns"]
+  #   image: centos:8
+  #   dockerfile_tpl: centos-systemd
 
   - name: ubuntu-1804
+    groups: ["pdns"]
     image: ubuntu:18.04
     dockerfile_tpl: debian-systemd
-    groups:
-      - pdns
-
-  - name: debian-8
-    image: debian:8
-    groups:
-      - pdns
 
   - name: debian-9
+    groups: ["pdns"]
     image: debian:9
     dockerfile_tpl: debian-systemd
-    groups:
-      - pdns
+
+  - name: debian-10
+    groups: ["pdns"]
+    image: debian:10
+    dockerfile_tpl: debian-systemd
 
   # In order to run the tests we need
   # a MySQL container to be up & running
@@ -60,6 +57,17 @@ provisioner:
   options:
     diff: True
     v: True
+  config_options:
+    defaults:
+      gathering: smart
+      fact_caching: jsonfile
+      fact_caching_connection: .ansible_cache
+      fact_caching_timeout: 7200
+    ssh_connection:
+      pipelining: true
+  inventory:
+    links:
+      host_vars: ../resources/host_vars/
   playbooks:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml
@@ -67,8 +75,11 @@ provisioner:
   lint:
     name: ansible-lint
     options:
-      # excludes "systemctl used in place of systemd module"
-      x: ["ANSIBLE0006"]
+      x:
+        # "systemctl used in place of systemd module"
+        - "ANSIBLE0006"
+        # "Tasks that run when changed should likely be handlers"
+        - "ANSIBLE0016"
 
 lint:
   name: yamllint
@@ -81,7 +92,7 @@ verifier:
   directory: ../resources/tests/all
   additional_files_or_dirs:
     # path relative to 'directory'
-    - ../repo-41/
+    - ../repo-42/
     - ../backend-sqlite/
     - ../backend-mysql/
   lint:

--- a/molecule/pdns-42/molecule.yml
+++ b/molecule/pdns-42/molecule.yml
@@ -80,6 +80,8 @@ provisioner:
         - "ANSIBLE0006"
         # "Tasks that run when changed should likely be handlers"
         - "ANSIBLE0016"
+        # "Shells that use pipes should set the pipefail option"
+        - "306"
 
 lint:
   name: yamllint

--- a/molecule/pdns-42/playbook.yml
+++ b/molecule/pdns-42/playbook.yml
@@ -3,7 +3,7 @@
 - hosts: pdns
   vars_files:
     - ../resources/vars/pdns-common.yml
-    - ../resources/vars/pdns-repo-41.yml
+    - ../resources/vars/pdns-repo-42.yml
     - ../resources/vars/pdns-backends.yml
   roles:
     - { role: pdns-ansible }

--- a/molecule/pdns-master/molecule.yml
+++ b/molecule/pdns-master/molecule.yml
@@ -11,38 +11,35 @@ dependency:
 
 platforms:
   - name: centos-6
+    groups: ["pdns"]
     image: centos:6
-    groups:
-      - pdns
 
   - name: centos-7
+    groups: ["pdns"]
     image: centos:7
     dockerfile_tpl: centos-systemd
-    groups:
-      - pdns
 
-  - name: ubuntu-1604
-    image: ubuntu:16.04
-    dockerfile_tpl: debian-systemd
-    groups:
-      - pdns
+  # Temporarely disable CentOS 8 due to:
+  # https://github.com/ansible/ansible/issues/64963
+  # - name: centos-8
+  #   groups: ["pdns"]
+  #   image: centos:8
+  #   dockerfile_tpl: centos-systemd
 
   - name: ubuntu-1804
+    groups: ["pdns"]
     image: ubuntu:18.04
     dockerfile_tpl: debian-systemd
-    groups:
-      - pdns
-
-  - name: debian-8
-    image: debian:8
-    groups:
-      - pdns
 
   - name: debian-9
+    groups: ["pdns"]
     image: debian:9
     dockerfile_tpl: debian-systemd
-    groups:
-      - pdns
+
+  - name: debian-10
+    groups: ["pdns"]
+    image: debian:10
+    dockerfile_tpl: debian-systemd
 
   # In order to run the tests we need
   # a MySQL container to be up & running
@@ -60,6 +57,17 @@ provisioner:
   options:
     diff: True
     v: True
+  config_options:
+    defaults:
+      gathering: smart
+      fact_caching: jsonfile
+      fact_caching_connection: .ansible_cache
+      fact_caching_timeout: 7200
+    ssh_connection:
+      pipelining: true
+  inventory:
+    links:
+      host_vars: ../resources/host_vars/
   playbooks:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml
@@ -67,8 +75,11 @@ provisioner:
   lint:
     name: ansible-lint
     options:
-      # excludes "systemctl used in place of systemd module"
-      x: ["ANSIBLE0006"]
+      x:
+        # "systemctl used in place of systemd module"
+        - "ANSIBLE0006"
+        # "Tasks that run when changed should likely be handlers"
+        - "ANSIBLE0016"
 
 lint:
   name: yamllint

--- a/molecule/pdns-master/molecule.yml
+++ b/molecule/pdns-master/molecule.yml
@@ -80,6 +80,8 @@ provisioner:
         - "ANSIBLE0006"
         # "Tasks that run when changed should likely be handlers"
         - "ANSIBLE0016"
+        # "Shells that use pipes should set the pipefail option"
+        - "306"
 
 lint:
   name: yamllint

--- a/molecule/resources/Dockerfile.centos-systemd.j2
+++ b/molecule/resources/Dockerfile.centos-systemd.j2
@@ -22,5 +22,6 @@ VOLUME [ "/sys/fs/cgroup" ]
 
 CMD ["/usr/sbin/init"]
 
-RUN if [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python python-devel python2-dnf net-tools bash && dnf clean all; \
+RUN if [ $(command -v dnf) ] && [ $(rpm -E %{rhel}) -eq 8 ]; then dnf makecache && dnf --assumeyes install python3 python3-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl net-tools bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; fi

--- a/molecule/resources/host_vars/centos-8.yml
+++ b/molecule/resources/host_vars/centos-8.yml
@@ -1,0 +1,3 @@
+---
+
+ansible_python_interpreter: "/usr/bin/python3"

--- a/molecule/resources/tests/all/test_common.py
+++ b/molecule/resources/tests/all/test_common.py
@@ -44,4 +44,4 @@ def systemd_override(host):
         assert f.exists
         assert f.user == 'root'
         assert f.group == 'root'
-        assert 'LimitCORE=infinity' in f.content
+        assert f.contains('LimitCORE=infinity')

--- a/molecule/resources/tests/backend-mysql/test_backend_mysql.py
+++ b/molecule/resources/tests/backend-mysql/test_backend_mysql.py
@@ -34,6 +34,6 @@ def test_database_tables(host):
                           "--batch --skip-column-names " +
                           "--execute=\"SELECT DISTINCT table_name FROM information_schema.columns WHERE table_schema = '%s'\"" % dbname)
 
-    for table in [ 'domains', 'records', 'supermasters', 'comments'
+    for table in [ 'domains', 'records', 'supermasters', 'comments',
             'domainmetadata', 'cryptokeys', 'tsigkeys' ]:
-        assert cmd.stdout.contains(table)
+        assert table in cmd.stdout

--- a/molecule/resources/tests/backend-mysql/test_backend_mysql.py
+++ b/molecule/resources/tests/backend-mysql/test_backend_mysql.py
@@ -20,24 +20,20 @@ def test_config(host):
         dbname = host.check_output('hostname -s').replace('.', '_')
 
         assert f.exists
-        assert 'launch+=gmysql' in f.content
-        assert 'gmysql-host=mysql' in f.content
-        assert 'gmysql-password=pdns' in f.content
-        assert 'gmysql-dbname=' + dbname in f.content
-        assert 'gmysql-user=pdns' in f.content
+        assert f.contains('launch+=gmysql')
+        assert f.contains('gmysql-host=mysql')
+        assert f.contains('gmysql-password=pdns')
+        assert f.contains('gmysql-dbname=' + dbname)
+        assert f.contains('gmysql-user=pdns')
 
 
 def test_database_tables(host):
     dbname = host.check_output('hostname -s').replace('.', '_')
 
-    cmd = host.run("mysql --user=\"pdns\" --password=\"pdns\" --host=\"mysql\" " + 
+    cmd = host.run("mysql --user=\"pdns\" --password=\"pdns\" --host=\"mysql\" " +
                           "--batch --skip-column-names " +
                           "--execute=\"SELECT DISTINCT table_name FROM information_schema.columns WHERE table_schema = '%s'\"" % dbname)
 
-    assert 'domains' in cmd.stdout
-    assert 'records' in cmd.stdout
-    assert 'supermasters' in cmd.stdout
-    assert 'comments' in cmd.stdout
-    assert 'domainmetadata' in cmd.stdout
-    assert 'cryptokeys' in cmd.stdout
-    assert 'tsigkeys' in cmd.stdout
+    for table in [ 'domains', 'records', 'supermasters', 'comments'
+            'domainmetadata', 'cryptokeys', 'tsigkeys' ]:
+        assert cmd.stdout.contains(table)

--- a/molecule/resources/tests/backend-sqlite/test_backend_sqlite.py
+++ b/molecule/resources/tests/backend-sqlite/test_backend_sqlite.py
@@ -19,5 +19,5 @@ def test_database_exists(host):
     assert f.exists
     assert f.user == 'pdns'
     assert f.group == 'pdns'
-    assert f.mode == 416
+    assert f.mode == 0o416
     assert f.size > 10000

--- a/molecule/resources/tests/backend-sqlite/test_backend_sqlite.py
+++ b/molecule/resources/tests/backend-sqlite/test_backend_sqlite.py
@@ -19,5 +19,5 @@ def test_database_exists(host):
     assert f.exists
     assert f.user == 'pdns'
     assert f.group == 'pdns'
-    assert f.mode == 0o416
+    assert f.mode == 0o640
     assert f.size > 10000

--- a/molecule/resources/tests/repo-42/test_repo_42.py
+++ b/molecule/resources/tests/repo-42/test_repo_42.py
@@ -6,9 +6,9 @@ rhel_os = ['redhat', 'centos']
 def test_repo_file(host):
     f = None
     if host.system_info.distribution.lower() in debian_os:
-        f = host.file('/etc/apt/sources.list.d/powerdns-auth-41.list')
+        f = host.file('/etc/apt/sources.list.d/powerdns-auth-42.list')
     if host.system_info.distribution.lower() in rhel_os:
-        f = host.file('/etc/yum.repos.d/powerdns-auth-41.repo')
+        f = host.file('/etc/yum.repos.d/powerdns-auth-42.repo')
 
     assert f.exists
     assert f.user == 'root'
@@ -18,15 +18,15 @@ def test_repo_file(host):
 def test_pdns_repo(host):
     f = None
     if host.system_info.distribution.lower() in debian_os:
-        f = host.file('/etc/apt/sources.list.d/powerdns-auth-41.list')
+        f = host.file('/etc/apt/sources.list.d/powerdns-auth-42.list')
     if host.system_info.distribution.lower() in rhel_os:
-        f = host.file('/etc/yum.repos.d/powerdns-auth-41.repo')
+        f = host.file('/etc/yum.repos.d/powerdns-auth-42.repo')
 
     assert f.exists
-    assert f.contains('auth-41')
+    assert f.contains('auth-42')
 
 
 def test_pdns_version(host):
     cmd = host.run('/usr/sbin/pdns_server --version')
 
-    assert 'PowerDNS Authoritative Server 4.1.' in cmd.stderr
+    assert cmd.stderr.contains('PowerDNS Authoritative Server 4.2.')

--- a/molecule/resources/tests/repo-42/test_repo_42.py
+++ b/molecule/resources/tests/repo-42/test_repo_42.py
@@ -29,4 +29,5 @@ def test_pdns_repo(host):
 def test_pdns_version(host):
     cmd = host.run('/usr/sbin/pdns_server --version')
 
-    assert cmd.stderr.contains('PowerDNS Authoritative Server 4.2.')
+    assert 'PowerDNS Authoritative Server' in cmd.stderr
+    assert '4.2' in cmd.stderr

--- a/molecule/resources/tests/repo-master/test_repo_master.py
+++ b/molecule/resources/tests/repo-master/test_repo_master.py
@@ -29,4 +29,5 @@ def test_pdns_repo(host):
 def test_pdns_version(host):
     cmd = host.run('/usr/sbin/pdns_server --version')
 
-    assert cmd.stderr.contains('PowerDNS Authoritative Server 0.0.')
+    assert 'PowerDNS Authoritative Server' in cmd.stderr
+    assert 'master' in cmd.stderr

--- a/molecule/resources/tests/repo-master/test_repo_master.py
+++ b/molecule/resources/tests/repo-master/test_repo_master.py
@@ -29,4 +29,4 @@ def test_pdns_repo(host):
 def test_pdns_version(host):
     cmd = host.run('/usr/sbin/pdns_server --version')
 
-    assert 'PowerDNS Authoritative Server 0.0.' in cmd.stderr
+    assert cmd.stderr.contains('PowerDNS Authoritative Server 0.0.')

--- a/molecule/resources/vars/pdns-repo-41.yml
+++ b/molecule/resources/vars/pdns-repo-41.yml
@@ -1,7 +1,0 @@
----
-
-##
-# PowerDNS 4.1.x Repository
-##
-
-pdns_install_repo: "{{ pdns_auth_powerdns_repo_41 }}"

--- a/molecule/resources/vars/pdns-repo-42.yml
+++ b/molecule/resources/vars/pdns-repo-42.yml
@@ -1,0 +1,7 @@
+---
+
+##
+# PowerDNS 4.2.x Repository
+##
+
+pdns_install_repo: "{{ pdns_auth_powerdns_repo_42 }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -33,7 +33,7 @@
     src: pdns.conf.j2
     dest: "{{ pdns_config_dir }}/{{ pdns_config_file }}"
     owner: "root"
-    group: "root"
+    group: "{{ pdns_group }}"
     mode: 0640
   notify: restart PowerDNS
 
@@ -43,5 +43,5 @@
     state: directory
     owner: "root"
     group: "root"
-    mode: 0750
+    mode: 0755
   when: "pdns_config['include-dir'] is defined"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -26,7 +26,7 @@
     state: directory
     owner: "root"
     group: "root"
-    mode: 0750
+    mode: 0755
 
 - name: Generate the PowerDNS Authoritative Server configuration
   template:

--- a/tasks/database-mysql.yml
+++ b/tasks/database-mysql.yml
@@ -2,20 +2,18 @@
 
 - name: Install the MySQL dependencies on RedHat
   package:
-    name: "{{ item }}"
+    name:
+      - mysql
+      - MySQL-python
     state: present
-  with_items:
-    - mysql
-    - MySQL-python
   when: ansible_os_family == 'RedHat'
 
 - name: Install the MySQL dependencies on Debian
   package:
-    name: "{{ item }}"
+    name:
+      - default-mysql-client
+      - python-mysqldb
     state: present
-  with_items:
-    - mysql-client
-    - python-mysqldb
   when: ansible_os_family == 'Debian'
 
 - name: Create the PowerDNS Authoritative Server MySQL databases
@@ -56,25 +54,35 @@
   register: _pdns_check_mysql_db
   changed_when: False
 
-- name: Define the PowerDNS Authoritative Server database MySQL schema file path on RedHat < 7
-  set_fact:
-    _pdns_mysql_schema_file: "/usr/share/doc/pdns/schema.mysql.sql"
-  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version | int < 7
+- block:
 
-- name: Define the PowerDNS Authoritative Server database MySQL schema file path on RedHat >= 7
-  set_fact:
-    _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql-{{ _pdns_running_version | regex_replace('-rc[\\d]*$', '') }}/schema.mysql.sql"
-  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 7
+    - name: Define the PowerDNS Authoritative Server database MySQL schema file path on RedHat < 7 and PowerDNS < 4.2.0
+      set_fact:
+        _pdns_mysql_schema_file: "/usr/share/doc/pdns/schema.mysql.sql"
+      when: ansible_distribution_major_version | int < 7
+        and (_pdns_running_version | regex_replace('-rc[\\d]*$', '')) is version_compare('4.2.0', '<')
 
-- name: Define the PowerDNS Authoritative Server database MySQL schema file path on Debian
-  set_fact:
-    _pdns_mysql_schema_file: "/usr/share/dbconfig-common/data/pdns-backend-mysql/install/mysql"
-  when: "ansible_os_family == 'Debian' and pdns_install_repo | length == 0"
+    - name: Define the PowerDNS Authoritative Server database MySQL schema file path on RedHat >= 7 or PowerDNS >= 4.2.0
+      set_fact:
+        _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql-{{ _pdns_running_version | regex_replace('-rc[\\d]*$', '') }}/schema.mysql.sql"
+      when: ansible_distribution_major_version | int >= 7
+        or (_pdns_running_version | regex_replace('-rc[\\d]*$', '')) is version_compare('4.2.0', '>=')
 
-- name: Define the PowerDNS Authoritative Server database MySQL schema file path on Debian
-  set_fact:
-    _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql/schema.mysql.sql"
-  when: "ansible_os_family == 'Debian' and pdns_install_repo | length > 0"
+  when: ansible_os_family == 'RedHat'
+
+- block:
+
+    - name: Define the PowerDNS Authoritative Server database MySQL schema file path on Debian
+      set_fact:
+        _pdns_mysql_schema_file: "/usr/share/dbconfig-common/data/pdns-backend-mysql/install/mysql"
+      when: pdns_install_repo | length == 0
+
+    - name: Define the PowerDNS Authoritative Server database MySQL schema file path on Debian
+      set_fact:
+        _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql/schema.mysql.sql"
+      when: pdns_install_repo | length > 0
+
+  when: ansible_os_family == 'Debian'
 
 - name: Import the PowerDNS Authoritative Server MySQL schema
   mysql_db:

--- a/tasks/database-mysql.yml
+++ b/tasks/database-mysql.yml
@@ -60,13 +60,13 @@
       set_fact:
         _pdns_mysql_schema_file: "/usr/share/doc/pdns/schema.mysql.sql"
       when: ansible_distribution_major_version | int < 7
-        and (_pdns_running_version | regex_replace('-rc[\\d]*$', '')) is version_compare('4.2.0', '<')
+        and _pdns_running_version is version_compare('4.2.0', '<')
 
     - name: Define the PowerDNS Authoritative Server database MySQL schema file path on RedHat >= 7 or PowerDNS >= 4.2.0
       set_fact:
-        _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql-{{ _pdns_running_version | regex_replace('-rc[\\d]*$', '') }}/schema.mysql.sql"
+        _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql-{{ _pdns_running_version }}/schema.mysql.sql"
       when: ansible_distribution_major_version | int >= 7
-        or (_pdns_running_version | regex_replace('-rc[\\d]*$', '')) is version_compare('4.2.0', '>=')
+        or _pdns_running_version is version_compare('4.2.0', '>=')
 
   when: ansible_os_family == 'RedHat'
 

--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -1,33 +1,54 @@
 ---
 
+- name: Install the SQLite dependencies on RedHat
+  package:
+    name: sqlite
+    state: present
+  when: ansible_os_family == 'RedHat'
+
+- name: Install the SQLite dependencies on Debian
+  package:
+    name: sqlite3
+    state: present
+  when: ansible_os_family == 'Debian'
+
 - name: Ensure that the directories containing the PowerDNS Authoritative Server SQLite databases exist
   file:
     name: "{{ item | dirname }}"
-    owner: "{{ pdns_user }}"
-    group: "{{ pdns_group }}"
+    owner: "root"
+    group: "root"
     state: directory
-    mode: 0750
+    mode: 0755
   with_items: "{{ pdns_sqlite_databases_locations }}"
 
-- name: Create the PowerDNS Authoritative Server SQLite databases on RedHat < 7
-  shell: "sqlite3 {{ item }} < /usr/share/doc/pdns/schema.sqlite3.sql"
-  args:
-    creates: "{{ item }}"
-  with_items: "{{ pdns_sqlite_databases_locations }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version | int < 7
+- block:
 
-- name: Create the PowerDNS Authoritative Server SQLite databases on RedHat >= 7
-  shell: "sqlite3 {{ item }} < /usr/share/doc/pdns-backend-sqlite-{{ _pdns_running_version | regex_replace('-rc[\\d]*$', '') }}/schema.sqlite3.sql"
-  args:
-    creates: "{{ item }}"
-  with_items: "{{ pdns_sqlite_databases_locations }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version | int >= 7
+    - name: Create the PowerDNS Authoritative Server SQLite databases on RedHat < 7 and PowerDNS < 4.2.0
+      shell: "sqlite3 {{ item }} < /usr/share/doc/pdns/schema.sqlite3.sql"
+      args:
+        creates: "{{ item }}"
+      with_items: "{{ pdns_sqlite_databases_locations }}"
+      when: ansible_distribution_major_version | int < 7
+        and (_pdns_running_version | regex_replace('-rc[\\d]*$', '')) is version_compare('4.2.0', '<')
 
-- name: Create the PowerDNS Authoritative Server SQLite databases on Debian
-  shell: "sqlite3 {{ item }} < /usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql"
-  args:
-    creates: "{{ item }}"
-  with_items: "{{ pdns_sqlite_databases_locations }}"
+    - name: Create the PowerDNS Authoritative Server SQLite databases on RedHat >= 7 or PowerDNS >= 4.2.0
+      shell: "sqlite3 {{ item }} < /usr/share/doc/pdns-backend-sqlite-{{ _pdns_running_version | regex_replace('-rc[\\d]*$', '') }}/schema.sqlite3.sql"
+      args:
+        creates: "{{ item }}"
+      with_items: "{{ pdns_sqlite_databases_locations }}"
+      when: ansible_distribution_major_version | int >= 7
+        or (_pdns_running_version | regex_replace('-rc[\\d]*$', '')) is version_compare('4.2.0', '>=')
+
+  when: ansible_os_family == "RedHat"
+
+- block:
+
+    - name: Create the PowerDNS Authoritative Server SQLite databases on Debian
+      shell: "sqlite3 {{ item }} < /usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql"
+      args:
+        creates: "{{ item }}"
+      with_items: "{{ pdns_sqlite_databases_locations }}"
+
   when: ansible_os_family == "Debian"
 
 - name: Check the PowerDNS Authoritative Server SQLite databases permissions

--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -29,15 +29,15 @@
         creates: "{{ item }}"
       with_items: "{{ pdns_sqlite_databases_locations }}"
       when: ansible_distribution_major_version | int < 7
-        and (_pdns_running_version | regex_replace('-rc[\\d]*$', '')) is version_compare('4.2.0', '<')
+        and _pdns_running_version is version_compare('4.2.0', '<')
 
     - name: Create the PowerDNS Authoritative Server SQLite databases on RedHat >= 7 or PowerDNS >= 4.2.0
-      shell: "sqlite3 {{ item }} < /usr/share/doc/pdns-backend-sqlite-{{ _pdns_running_version | regex_replace('-rc[\\d]*$', '') }}/schema.sqlite3.sql"
+      shell: "sqlite3 {{ item }} < /usr/share/doc/pdns-backend-sqlite-{{ _pdns_running_version }}/schema.sqlite3.sql"
       args:
         creates: "{{ item }}"
       with_items: "{{ pdns_sqlite_databases_locations }}"
       when: ansible_distribution_major_version | int >= 7
-        or (_pdns_running_version | regex_replace('-rc[\\d]*$', '')) is version_compare('4.2.0', '>=')
+        or _pdns_running_version is version_compare('4.2.0', '>=')
 
   when: ansible_os_family == "RedHat"
 

--- a/tasks/inspect.yml
+++ b/tasks/inspect.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: Obtain the version of the running PowerDNS Authoritative Server
-  shell: "pdns_server --version 2>&1 | awk '/PowerDNS Authoritative/{print $7}'"
+  shell: |
+    set -o pipefail
+    pdns_server --version 2>&1 | awk '/PowerDNS Authoritative/{print $7}'
   register: _pdns_version
   check_mode: no
   changed_when: False

--- a/tasks/inspect.yml
+++ b/tasks/inspect.yml
@@ -9,4 +9,4 @@
 
 - name: Export the running PowerDNS Authoritative Server version to a variable
   set_fact:
-    _pdns_running_version: "{{ _pdns_version['stdout'] }}"
+    _pdns_running_version: "{{ _pdns_version['stdout'] | regex_replace('-[.\\d\\w]+$', '') }}"

--- a/tasks/inspect.yml
+++ b/tasks/inspect.yml
@@ -2,7 +2,6 @@
 
 - name: Obtain the version of the running PowerDNS Authoritative Server
   shell: |
-    set -o pipefail
     pdns_server --version 2>&1 | awk '/PowerDNS Authoritative/{print $7}'
   register: _pdns_version
   check_mode: no

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-molecule==2.14.0
+molecule==2.22.0
 docker-py==1.10.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,20 @@
 [tox]
 minversion = 1.8
-envlist = py{27}-ansible{22,23,24,25,26,27}
+envlist = py{27,36}-ansible{27,28,29}
 skipsdist = true
 
 [travis:env]
 ANSIBLE=
-  2.2: ansible22
-  2.3: ansible23
-  2.4: ansible24
-  2.5: ansible25
-  2.6: ansible26
   2.7: ansible27
+  2.8: ansible28
+  2.9: ansible29
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible22: ansible<2.3
-    ansible23: ansible<2.4
-    ansible24: ansible<2.5
-    ansible25: ansible<2.6
-    ansible26: ansible<2.7
     ansible27: ansible<2.8
+    ansible28: ansible<2.9
+    ansible29: ansible<2.10
 commands =
     {posargs:molecule test --all --destroy always}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -35,3 +35,12 @@ pdns_auth_powerdns_repo_42:
   yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/auth-42"
   yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/auth-42/debug"
   name: "powerdns-auth-42"
+
+pdns_auth_powerdns_repo_43:
+  apt_repo_origin: "repo.powerdns.com"
+  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-auth-43 main"
+  gpg_key: "http://repo.powerdns.com/FD380FBB-pub.asc"
+  gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
+  yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/auth-43"
+  yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/auth-43/debug"
+  name: "powerdns-auth-43"


### PR DESCRIPTION
This PR

- adds support to the Auth 4.3.x
- updates the CI to test against the Auth  4.2.x
- addresses some concerns with the config directories permissions raised in https://github.com/PowerDNS/pdns-ansible/pull/57 and https://github.com/PowerDNS/pdns-ansible/pull/65
- installs SQLite3 as reported in https://github.com/PowerDNS/pdns-ansible/issues/64
- updates the CI to test against Ansible 2.7, 2.8. and 2.9
- incorporates the feedback from https://github.com/PowerDNS/pdns-ansible/issues/58