### PR TITLE
When: use right ownership of SQLite directory

### DIFF
--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -21,7 +21,7 @@
     mode: 0755
   with_items: "{{ pdns_sqlite_databases_locations }}"
   when: _pdns_running_version is version_compare('4.2.0', '<')
-  
+
 - name: Ensure that the directories containing the PowerDNS SQLite databases exist
   file:
     name: "{{ item | dirname }}"

--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -20,6 +20,17 @@
     state: directory
     mode: 0755
   with_items: "{{ pdns_sqlite_databases_locations }}"
+  when: _pdns_running_version is version_compare('4.2.0', '<')
+  
+- name: Ensure that the directories containing the PowerDNS SQLite databases exist
+  file:
+    name: "{{ item | dirname }}"
+    owner: "pdns"
+    group: "pdns"
+    state: directory
+    mode: 0755
+  with_items: "{{ pdns_sqlite_databases_locations }}"
+  when: _pdns_running_version is version_compare('4.2.0', '>=')
 
 - block:
 


### PR DESCRIPTION
When condition to use different ownership of SQLite directory when version 4.2 is being installed. Related with Issue #71 