### PR TITLE
FIXED: mysql schema path for debian 10

### DIFF
--- a/tasks/database-mysql.yml
+++ b/tasks/database-mysql.yml
@@ -75,7 +75,12 @@
     - name: Define the PowerDNS database MySQL schema file path on Debian
       set_fact:
         _pdns_mysql_schema_file: "/usr/share/dbconfig-common/data/pdns-backend-mysql/install/mysql"
-      when: pdns_install_repo | length == 0
+      when: pdns_install_repo | length == 0 and  ansible_distribution_major_version | int < 10
+
+    - name: Define the PowerDNS database MySQL schema file path on Debian
+      set_fact:
+        _pdns_mysql_schema_file: "/usr/share/pdns-backend-mysql/schema/schema.mysql.sql"
+      when: pdns_install_repo | length == 0 and  ansible_distribution_major_version | int >= 10
 
     - name: Define the PowerDNS database MySQL schema file path on Debian
       set_fact:


### PR DESCRIPTION
**FIXED**:
_mysql schema path for debian 10 as support for dbconfig was dropped in pdns = 4.1.3-4 on 31 Jul 2018_
resulting in a error at
_TASK [pdns : Import the PowerDNS MySQL schema]_
with
_"msg": "target /usr/share/dbconfig-common/data/pdns-backend-mysql/install/mysql does not exist on the host"_