### PR TITLE
allow adding apt_key's from a file on the ansible server

### DIFF
--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -5,11 +5,20 @@
     name: gnupg
     state: present
 
-- name: Import the PowerDNS APT Repository key
+- name: Import the PowerDNS APT Repository key from URL
   apt_key:
     url: "{{ pdns_install_repo['gpg_key'] }}"
     id: "{{ pdns_install_repo['gpg_key_id'] | default('') }}"
     state: present
+  when: pdns_install_repo['gpg_key'] is regex("^[a-z]{3,}://")
+  register: _pdns_apt_key
+
+- name: Import the PowerDNS APT Repository key from File
+  apt_key:
+    data: "{{ lookup('file',  pdns_install_repo['gpg_key']) }}"
+    id: "{{ pdns_install_repo['gpg_key_id'] | default('') }}"
+    state: present
+  when: not pdns_install_repo['gpg_key'] is regex("^[a-z]{3,}://")
   register: _pdns_apt_key
 
 - name: Add the PowerDNS APT Repository


### PR DESCRIPTION
Allow using a apt_key from the ansible hosts instead of fetching it from a url