### PR TITLE
Ensure the file ownership and overrides are correct for 4.3+

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,8 +61,10 @@ pdns_debug_symbols_package_name: "{{ default_pdns_debug_symbols_package_name }}"
 # NOTE: at the moment, we don't create a user as we assume the package creates
 # a "pdns" user and group. If you change these variables, make sure to create
 # the user and groups before applying this role
-pdns_user: pdns
-pdns_group: pdns
+pdns_user: "pdns"
+pdns_group: "pdns"
+pdns_file_owner: "root"
+pdns_file_group: "{{ pdns_group }}"
 
 # Name of the PowerDNS Authoritative Server Service
 pdns_service_name: "pdns"
@@ -89,7 +91,7 @@ pdns_config: {}
 #  local-port: '5300'
 
 # Dict with overrides for the service (systemd only)
-pdns_service_overrides: {}
+pdns_service_overrides: "{{ default_pdns_service_overrides }}"
 # pdns_service_overrides:
 #   LimitNOFILE: 10000
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -22,23 +22,22 @@
     when: not pdns_disable_handlers
       and _pdns_override_unit.changed
 
-  when: pdns_service_overrides != {}
-    and ansible_service_mgr == "systemd"
+  when: ansible_service_mgr == "systemd"
 
 - name: Ensure that the PowerDNS configuration directory exists
   file:
     name: "{{ pdns_config_dir }}"
     state: directory
-    owner: "root"
-    group: "root"
-    mode: 0755
+    owner: "{{ pdns_file_owner }}"
+    group: "{{ pdns_file_group }}"
+    mode: 0750
 
 - name: Generate the PowerDNS configuration
   template:
     src: pdns.conf.j2
     dest: "{{ pdns_config_dir }}/{{ pdns_config_file }}"
-    owner: "root"
-    group: "{{ pdns_group }}"
+    owner: "{{ pdns_file_owner }}"
+    group: "{{ pdns_file_group }}"
     mode: 0640
   register: _pdns_configuration
 
@@ -46,9 +45,9 @@
   file:
     name: "{{ pdns_config['include-dir'] }}"
     state: directory
-    owner: "root"
-    group: "root"
-    mode: 0755
+    owner: "{{ pdns_file_owner }}"
+    group: "{{ pdns_file_group }}"
+    mode: 0750
   when: "pdns_config['include-dir'] is defined"
 
 - name: Restart PowerDNS

--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -15,10 +15,10 @@
 - name: Ensure that the directories containing the PowerDNS SQLite databases exist
   file:
     name: "{{ item | dirname }}"
-    owner: "root"
-    group: "root"
+    owner: "{{ pdns_user }}"
+    group: "{{ pdns_group }}"
     state: directory
-    mode: 0755
+    mode: 0750
   with_items: "{{ pdns_sqlite_databases_locations }}"
 
 - block:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -44,3 +44,10 @@ pdns_auth_powerdns_repo_43:
   yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/auth-43"
   yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/auth-43/debug"
   name: "powerdns-auth-43"
+
+default_pdns_service_overrides: >-
+  {{  { 'User'  : pdns_user
+      , 'Group' : pdns_group
+      } if _pdns_package_version is version('4.3', operator='ge')
+        else {}
+  }}


### PR DESCRIPTION
In PowerDNS 4.3+, the service is started as the pdns user by default.