### PR TITLE
doc: update ansible requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An Ansible role created by the folks behind PowerDNS to setup the [PowerDNS Auth
 
 ## Requirements
 
-An Ansible 2.2 or higher installation.
+An Ansible 2.7 or higher installation.
 
 ## Dependencies
 


### PR DESCRIPTION
This commit updates the documentation to mention the minimum Ansible
version required is 2.7

Fixes: #88

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>