### PR TITLE
configure: refact systemctl daemon-reload task

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -19,7 +19,8 @@
     when: pdns_service_overrides | length > 0
 
   - name: Reload systemd
-    command: systemctl daemon-reload
+    systemd:
+      daemon_reload: yes
     when: not pdns_disable_handlers
       and _pdns_override_unit.changed
 


### PR DESCRIPTION
There's a way to achieve this operation without using `command`
module, let's use `systemd` module instead.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>