### PR TITLE
Fixed the schema.sqlite3.sql path on RedHat 8

### DIFF
--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -36,7 +36,7 @@
 
     - name: Define the PowerDNS SQLite schema file path on RedHat 8 and PowerDNS >= 4.2.0
       set_fact:
-        _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-sqlite/schema.sqlite3.sql"
+        _pdns_mysql_schema_file: "/usr/share/doc/pdns/schema.sqlite3.sql"
       when:
         - ansible_distribution_major_version | int == 8
         - _pdns_running_version is version_compare('4.2.0', '>=')


### PR DESCRIPTION
Sqlite schema files are located under /usr/share/doc/pdns/ (checked with pdns 4.4.0). 