### PR TITLE
myql and sqlite3 schema path/filename variable add

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,27 +228,12 @@ pdns_lmdb_databases_locations: []
 Locations of the LMDB databases that have to be created if using the
 `lmdb` backend.
 
-Locations of the mysql and sqlite3 base schema for RedHat platform
+Locations of the mysql and sqlite3 base schema
 ```yaml
-pdns_rh_mysql_schema_file: {{}}
+pdns_mysql_schema_file: {{}}
 
-pdns_rh_sqlite3_schema_file: {{}}
+pdns_sqlite3_schema_file: {{}}
 ```
-
-Locations of the mysql and sqlite3 base schema for Debian based platform
-```yaml
-pdns_deb_mysql_schema_file: {{}}
-
-pdns_deb_sqlite3_schema_file: {{}}
-```
-
-Locations of the mysql and sqlite3 base schema for ArchLinux platform
-```yaml
-pdns_arch_mysql_schema_file: {{}}
-
-pdns_arch_sqlite3_schema_file: {{}}
-```
-
 
 ## Example Playbooks
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,28 @@ pdns_lmdb_databases_locations: []
 Locations of the LMDB databases that have to be created if using the
 `lmdb` backend.
 
+Locations of the mysql and sqlite3 base schema for RedHat platform
+```yaml
+pdns_rh_mysql_schema_file: {{}}
+
+pdns_rh_sqlite3_schema_file: {{}}
+```
+
+Locations of the mysql and sqlite3 base schema for Debian based platform
+```yaml
+pdns_deb_mysql_schema_file: {{}}
+
+pdns_deb_sqlite3_schema_file: {{}}
+```
+
+Locations of the mysql and sqlite3 base schema for ArchLinux platform
+```yaml
+pdns_arch_mysql_schema_file: {{}}
+
+pdns_arch_sqlite3_schema_file: {{}}
+```
+
+
 ## Example Playbooks
 
 Run as a master using the bind backend (when you already have a `named.conf` file):

--- a/tasks/database-mysql.yml
+++ b/tasks/database-mysql.yml
@@ -44,51 +44,23 @@
   changed_when: False
 
 - block:
-
-    - name: Define the PowerDNS database MySQL schema file path on RedHat < 7 and PowerDNS < 4.2.0
+    - name: Define the PowerDNS database MySQL schema file path on Debian
       set_fact:
-        _pdns_mysql_schema_file: "/usr/share/doc/pdns/schema.mysql.sql"
-      when: ansible_distribution_major_version | int < 7
-        and _pdns_running_version is version_compare('4.2.0', '<')
-
-    - name: Define the PowerDNS database MySQL schema file path on RedHat >= 7 or PowerDNS >= 4.2.0
-      set_fact:
-        _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql-{{ _pdns_running_version }}/schema.mysql.sql"
-      when: ansible_distribution_major_version | int == 7
-        or _pdns_running_version is version_compare('4.2.0', '>=')
-
-    - name: Define the PowerDNS database MySQL schema file path on RedHat 8 and PowerDNS >= 4.2.0
-      set_fact:
-        _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql/schema.mysql.sql"
-      when:
-        - ansible_distribution_major_version | int == 8
-        - _pdns_running_version is version_compare('4.2.0', '>=')
-
-  when: ansible_os_family == 'RedHat'
+        _pdns_mysql_schema_file: "{{ pdns_deb_mysql_schema_file }}"
+  
+  when: ansible_os_family == 'Debian'
 
 - block:
-
-    - name: Define the PowerDNS database MySQL schema file path on Debian
+    - name: Define the PowerDNS database MySQL schema file path on RedHat
       set_fact:
-        _pdns_mysql_schema_file: "/usr/share/dbconfig-common/data/pdns-backend-mysql/install/mysql"
-      when: pdns_install_repo | length == 0 and  ansible_distribution_major_version | int < 10
-
-    - name: Define the PowerDNS database MySQL schema file path on Debian
-      set_fact:
-        _pdns_mysql_schema_file: "/usr/share/pdns-backend-mysql/schema/schema.mysql.sql"
-      when: pdns_install_repo | length == 0 and  ansible_distribution_major_version | int >= 10
-
-    - name: Define the PowerDNS database MySQL schema file path on Debian
-      set_fact:
-        _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql/schema.mysql.sql"
-      when: pdns_install_repo | length > 0
-
-  when: ansible_os_family == 'Debian'
+        _pdns_mysql_schema_file: "{{ pdns_rh_mysql_schema_file }}"
+  
+  when: ansible_os_family == 'RedHat'
 
 - block:
     - name: Define the PowerDNS DB schema file path on Arch Linux
       set_fact:
-        _pdns_mysql_schema_file: "/usr/share/doc/powerdns/schema.mysql.sql"
+        _pdns_mysql_schema_file: "{{ pdns_arch_mysql_schema_file }}"
 
   when: ansible_os_family == 'Archlinux'
 

--- a/tasks/database-mysql.yml
+++ b/tasks/database-mysql.yml
@@ -43,27 +43,6 @@
   register: _pdns_check_mysql_db
   changed_when: False
 
-- block:
-    - name: Define the PowerDNS database MySQL schema file path on Debian
-      set_fact:
-        _pdns_mysql_schema_file: "{{ pdns_deb_mysql_schema_file }}"
-  
-  when: ansible_os_family == 'Debian'
-
-- block:
-    - name: Define the PowerDNS database MySQL schema file path on RedHat
-      set_fact:
-        _pdns_mysql_schema_file: "{{ pdns_rh_mysql_schema_file }}"
-  
-  when: ansible_os_family == 'RedHat'
-
-- block:
-    - name: Define the PowerDNS DB schema file path on Arch Linux
-      set_fact:
-        _pdns_mysql_schema_file: "{{ pdns_arch_mysql_schema_file }}"
-
-  when: ansible_os_family == 'Archlinux'
-
 - name: Import the PowerDNS MySQL schema
   mysql_db:
     login_user: "{{ item['item']['value']['user'] }}"
@@ -72,6 +51,6 @@
     login_port: "{{ item['item']['port'] | default('3306') }}"
     name: "{{ item.item['value']['dbname'] }}"
     state: import
-    target: "{{ _pdns_mysql_schema_file }}"
+    target: "{{ pdns_mysql_schema_file }}"
   when: "item['item']['key'].split(':')[0] == 'gmysql' and item['stdout'] == '0'"
   with_items: "{{ _pdns_check_mysql_db['results'] }}"

--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -22,27 +22,13 @@
   with_items: "{{ pdns_sqlite_databases_locations }}"
 
 - block:
-    - name: Define the PowerDNS SQLite schema file path on RedHat < 7 and PowerDNS < 4.2.0
+    - name: Define the PowerDNS SQLite schema file path on RedHat 
       set_fact:
-        _pdns_mysql_schema_file: "/usr/share/doc/pdns/schema.sqlite3.sql"
-      when: ansible_distribution_major_version | int < 7
-        and _pdns_running_version is version_compare('4.2.0', '<')
-
-    - name: Define the PowerDNS SQLite schema file path on RedHat >= 7 or PowerDNS >= 4.2.0
-      set_fact:
-        _pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-sqlite-{{ _pdns_running_version }}/schema.sqlite3.sql"
-      when: ansible_distribution_major_version | int == 7
-        or _pdns_running_version is version_compare('4.2.0', '>=')
-
-    - name: Define the PowerDNS SQLite schema file path on RedHat 8 and PowerDNS >= 4.2.0
-      set_fact:
-        _pdns_mysql_schema_file: "/usr/share/doc/pdns/schema.sqlite3.sql"
-      when:
-        - ansible_distribution_major_version | int == 8
-        - _pdns_running_version is version_compare('4.2.0', '>=')
+        _pdns_sqlite3_schema_file: "{{ pdns_rh_sqlite3_schema_file }}"
+      when: ansible_os_family == "RedHat"
 
     - name: Create the PowerDNS SQLite databases on RedHat
-      shell: "sqlite3 {{ item }} < {{ _pdns_mysql_schema_file }}"
+      shell: "sqlite3 {{ item }} < {{ _pdns_sqlite3_schema_file }}"
       args:
         creates: "{{ item }}"
       with_items: "{{ pdns_sqlite_databases_locations }}"
@@ -52,7 +38,7 @@
 - block:
 
     - name: Create the PowerDNS SQLite databases on Debian
-      shell: "sqlite3 {{ item }} < /usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql"
+      shell: "sqlite3 {{ item }} < {{ pdns_deb_sqlite3_schema_file }}"
       args:
         creates: "{{ item }}"
       with_items: "{{ pdns_sqlite_databases_locations }}"
@@ -61,7 +47,7 @@
 
 - block:
     - name: Initiate the SQLite database on Arch Linux
-      shell: "sqlite3 {{ item }} < /usr/share/doc/powerdns/schema.sqlite3.sql"
+      shell: "sqlite3 {{ item }} < {{ pdns_arch_sqlite3_schema_file }}"
       args:
         creates: "{{ item }}"
       with_items: "{{ pdns_sqlite_databases_locations }}"

--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -21,38 +21,11 @@
     mode: 0750
   with_items: "{{ pdns_sqlite_databases_locations }}"
 
-- block:
-    - name: Define the PowerDNS SQLite schema file path on RedHat 
-      set_fact:
-        _pdns_sqlite3_schema_file: "{{ pdns_rh_sqlite3_schema_file }}"
-      when: ansible_os_family == "RedHat"
-
-    - name: Create the PowerDNS SQLite databases on RedHat
-      shell: "sqlite3 {{ item }} < {{ _pdns_sqlite3_schema_file }}"
-      args:
-        creates: "{{ item }}"
-      with_items: "{{ pdns_sqlite_databases_locations }}"
-
-  when: ansible_os_family == "RedHat"
-
-- block:
-
-    - name: Create the PowerDNS SQLite databases on Debian
-      shell: "sqlite3 {{ item }} < {{ pdns_deb_sqlite3_schema_file }}"
-      args:
-        creates: "{{ item }}"
-      with_items: "{{ pdns_sqlite_databases_locations }}"
-
-  when: ansible_os_family == "Debian"
-
-- block:
-    - name: Initiate the SQLite database on Arch Linux
-      shell: "sqlite3 {{ item }} < {{ pdns_arch_sqlite3_schema_file }}"
-      args:
-        creates: "{{ item }}"
-      with_items: "{{ pdns_sqlite_databases_locations }}"
-
-  when: ansible_os_family == "Archlinux"
+- name: Create the PowerDNS SQLite databases
+    shell: "sqlite3 {{ item }} < {{ pdns_sqlite3_schema_file }}"
+    args:
+      creates: "{{ item }}"
+    with_items: "{{ pdns_sqlite_databases_locations }}"
 
 - name: Check the PowerDNS SQLite databases permissions
   file:

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -14,6 +14,10 @@ pdns_mysql_packages:
   - python-pymysql
   - mariadb-clients
 
+  # Default DB schema file
+pdns_arch_mysql_schema_file: "/usr/share/doc/powerdns/schema.mysql.sql"
+pdns_arch_sqlite3_schema_file: "/usr/share/doc/powerdns/schema.sqlite3.sql"
+
 # Other defaults
 pdns_user: powerdns
 pdns_group: powerdns

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -14,10 +14,7 @@ pdns_mysql_packages:
   - python-pymysql
   - mariadb-clients
 
-  # Default DB schema file
-pdns_arch_mysql_schema_file: "/usr/share/doc/powerdns/schema.mysql.sql"
-pdns_arch_sqlite3_schema_file: "/usr/share/doc/powerdns/schema.sqlite3.sql"
-
+  
 # Other defaults
 pdns_user: powerdns
 pdns_group: powerdns

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -29,7 +29,3 @@ default_pdns_backends_packages:
 
 # The directory where the PowerDNS Authoritative Server configuration is located
 default_pdns_config_dir: "/etc/powerdns"
-
-# Default DB schema file
-pdns_deb_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql/schema.mysql.sql"
-pdns_deb_sqlite3_schema_file: "/usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -29,3 +29,7 @@ default_pdns_backends_packages:
 
 # The directory where the PowerDNS Authoritative Server configuration is located
 default_pdns_config_dir: "/etc/powerdns"
+
+# Default DB schema file
+pdns_deb_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql/schema.mysql.sql"
+pdns_deb_sqlite3_schema_file: "/usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql"

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -31,7 +31,3 @@ default_pdns_backends_packages:
 
 # The directory where the PowerDNS Authoritative Server configuration is located
 default_pdns_config_dir: "/etc/pdns"
-
-# Default DB schema file
-pdns_rh_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql/schema.mysql.sql"
-pdns_rh_sqlite3_schema_file: "/usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql"

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -31,3 +31,7 @@ default_pdns_backends_packages:
 
 # The directory where the PowerDNS Authoritative Server configuration is located
 default_pdns_config_dir: "/etc/pdns"
+
+# Default DB schema file
+pdns_rh_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql/schema.mysql.sql"
+pdns_rh_sqlite3_schema_file: "/usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -54,6 +54,11 @@ pdns_auth_powerdns_repo_44:
   yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/auth-44/debug"
   name: "powerdns-auth-44"
 
+pdns_mysql_schema_file: "/usr/share/doc/pdns-backend-mysql/schema.mysql.sql"
+
+pdns_sqlite3_schema_file: "/usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql"
+
+
 default_pdns_service_overrides: >-
   {{  { 'User'  : pdns_user
       , 'Group' : pdns_group


### PR DESCRIPTION
In order to avoid problems with the previous rules that forged the path/filename for the DB schema switching by case for different platform/version etc. I am proposing a fixed variable way to setup the path/filename using eg. vars/Debian.yml line entry.
Case one will be for ArchLinux platform case two for RH and Debian/Ubuntu platform.
In every case we have a different schema filename for mysql or sqlite3 obviously.