### PR TITLE
Remove depreciated "python-mysqldb" package to fix "No package matching 'python-mysqldb' is available" error on Debian 11

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -9,7 +9,6 @@ default_pdns_debug_symbols_package_name: "pdns-server-dbg"
 # Packages needed to install MySQL
 pdns_mysql_packages:
   - default-mysql-client
-  - python-mysqldb
   - python3-mysqldb
 
 # List of PowerDNS Authoritative Server Backends packages on Debian


### PR DESCRIPTION
Hi there!
Since I spent way too much time looking for a solution to #97 while running this Ansible role on a Server with Debian 11 (Bullseye), I decided to just remove the depreciated package and try if everything works - and it does!
There may be better ways to fix this (esp. considering backwards compatibility), but I thought I'd open this as a PR anyway, so we can discuss it!
_Cheers!_