### PR TITLE
fix for debian >= 11 regarding python-mysqldb package

### DIFF
--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -9,6 +9,7 @@ default_pdns_debug_symbols_package_name: "pdns-server-dbg"
 # Packages needed to install MySQL
 pdns_mysql_packages:
   - default-mysql-client
+  - python-mysqldb
   - python3-mysqldb
 
 # List of PowerDNS Authoritative Server Backends packages on Debian


### PR DESCRIPTION
fix for debian >= 11 regarding python-mysqldb package