### PR TITLE
removed nolog from pdns backend install

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,6 +29,7 @@
   package:
     name: "{{ pdns_backends_packages[item.key.split(':')[0]] }}{{ _pdns_package_version | default('') }}"
     state: present
-  no_log: True
   when: pdns_backends_packages[item.key.split(':')[0]] is defined
   with_dict: "{{ pdns_backends }}"
+  loop_control:
+    label: "{{ item.key }}"


### PR DESCRIPTION
removed nolog from pdns backend install as this is hiding the error message (i.e. hinting to the missing vault) but still hide the password in normal log