### PR TITLE
Add support for Rocky and AlmaLinux (which should _for now_ be CentOS like

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 # By default, no PowerDNS Authoritative Server repository will be configured by the role
 pdns_install_repo: ""
 
-# To install tje PowerDNS Authoritative Server from the 'master' official repository
+# To install the PowerDNS Authoritative Server from the 'master' official repository
 # use the following playbook snippet
 # - hosts: all
 #   roles:
@@ -146,6 +146,10 @@ pdns_sqlite_databases_locations: []
 # in the given locations.
 # NOTE: Requries lmdb backend to be installed on the machine.
 pdns_lmdb_databases_locations: []
+
+# By default, we'll load the MySQL default schema. Set this to Falso to disable loading the schema
+# (e.g. when importing your own dump later on)
+pdns_mysql_schema_load: true
 
 # Override the schema used to initialize the MySQL database
 # By default, this role tries to detect the correct file

--- a/tasks/database-mysql.yml
+++ b/tasks/database-mysql.yml
@@ -13,7 +13,7 @@
     login_port: "{{ item['value']['port'] | default('3306') }}"
     name: "{{ item['value']['dbname'] }}"
     state: present
-  when: "item.key.split(':')[0] == 'gmysql'"
+  when: "item.key.split(':')[0] == 'gmysql' and pdns_mysql_databases_credentials"
   no_log: True
   with_dict: "{{ pdns_backends | combine(pdns_mysql_databases_credentials, recursive=True) }}"
 
@@ -29,15 +29,17 @@
     priv: "{{ item[0]['dbname'] }}.*:ALL"
     append_privs: yes
     state: present
+  when: pdns_mysql_databases_credentials
   with_subelements:
     - "{{ pdns_backends | combine(pdns_mysql_databases_credentials, recursive=True) }}"
     - priv_host
     - skip_missing: yes
 
+# TODO: add support for file socket connections instead of host/port combos
 - name: Check if the MySQL databases are empty
   command: >
     mysql --user="{{ item['value']['user'] }}" --password="{{ item['value']['password'] }}"
-    --host="{{ item['value']['host'] }}" --port "{{ item['value']['port'] | default('3306') }}" --batch --skip-column-names
+    --host="{{ item['value']['host'] | default('localhost') }}" --port "{{ item['value']['port'] | default('3306') }}" --batch --skip-column-names
     --execute="SELECT COUNT(DISTINCT table_name) FROM information_schema.columns WHERE table_schema = '{{ item['value']['dbname'] }}'"
   when: item.key.split(':')[0] == 'gmysql'
   with_dict: "{{ pdns_backends }}"
@@ -64,11 +66,12 @@
   set_fact:
     pdns_mysql_schema_file_to_use: "{% if pdns_mysql_schema_file | length == 0 %}{{ pdns_mysql_schema_file_detected.stdout }}{% else %}{{ pdns_mysql_schema_file }}{% endif %}"
 
+# TODO: add support for file socket connections instead of host/port combos
 - name: Import the PowerDNS MySQL schema
   mysql_db:
     login_user: "{{ item['item']['value']['user'] }}"
     login_password: "{{ item['item']['value']['password'] }}"
-    login_host: "{{ item['item']['value']['host'] }}"
+    login_host: "{{ item['item']['value']['host'] | default('localhost') }}"
     login_port: "{{ item['item']['port'] | default('3306') }}"
     name: "{{ item.item['value']['dbname'] }}"
     state: import

--- a/tasks/database-mysql.yml
+++ b/tasks/database-mysql.yml
@@ -74,5 +74,5 @@
     state: import
     target: "{{ pdns_mysql_schema_file_to_use }}"
   no_log: True
-  when: "item['item']['key'].split(':')[0] == 'gmysql' and item['stdout'] == '0'"
+  when: "item['item']['key'].split(':')[0] == 'gmysql' and item['stdout'] == '0' and pdns_mysql_schema_load"
   with_items: "{{ _pdns_check_mysql_db['results'] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     - config
 
 - include_tasks: database-mysql.yml
-  when: "pdns_mysql_databases_credentials | length > 0"
+  when: "'gmysql' in pdns_backends"
   tags:
     - db
     - mysql

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -6,7 +6,7 @@
     yum:
       name: epel-release
       state: present
-    when: ansible_distribution in [ 'CentOS' ]
+    when: ansible_distribution in [ 'CentOS', 'Rocky', 'AlmaLinux' ]
 
   - name: Install epel-release on RHEL
     package:
@@ -29,7 +29,7 @@
     name: yum-plugin-priorities
     state: present
   when:
-    - ansible_distribution in [ 'CentOS' ]
+    - ansible_distribution in [ 'CentOS', 'Rocky', 'AlmaLinux' ]
     - ansible_distribution_major_version | int < 8
 
 - name: Add the PowerDNS YUM Repository

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -4,7 +4,7 @@
     name: pdns_can_network_connect_db
     state: yes
     persistent: yes
-  when: "pdns_mysql_databases_credentials | length > 0"
+  when: "'gmysql' in pdns_backends"
 
 - name: allow pdns to bind to udp high ports
   seport:


### PR DESCRIPTION
Adds support for Alma and Rocky linux, assume those are "identical" to CentOS for now.