### PR TITLE
Allow mysql-specific tasks to run based on backend, not on pdns_mysql_databases_credentials

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 # By default, no PowerDNS Authoritative Server repository will be configured by the role
 pdns_install_repo: ""
 
-# To install tje PowerDNS Authoritative Server from the 'master' official repository
+# To install the PowerDNS Authoritative Server from the 'master' official repository
 # use the following playbook snippet
 # - hosts: all
 #   roles:
@@ -146,6 +146,10 @@ pdns_sqlite_databases_locations: []
 # in the given locations.
 # NOTE: Requries lmdb backend to be installed on the machine.
 pdns_lmdb_databases_locations: []
+
+# By default, we'll load the MySQL default schema. Set this to Falso to disable loading the schema
+# (e.g. when importing your own dump later on)
+pdns_mysql_schema_load: true
 
 # Override the schema used to initialize the MySQL database
 # By default, this role tries to detect the correct file

--- a/tasks/database-mysql.yml
+++ b/tasks/database-mysql.yml
@@ -13,7 +13,7 @@
     login_port: "{{ item['value']['port'] | default('3306') }}"
     name: "{{ item['value']['dbname'] }}"
     state: present
-  when: "item.key.split(':')[0] == 'gmysql'"
+  when: "item.key.split(':')[0] == 'gmysql' and pdns_mysql_databases_credentials"
   no_log: True
   with_dict: "{{ pdns_backends | combine(pdns_mysql_databases_credentials, recursive=True) }}"
 
@@ -29,20 +29,22 @@
     priv: "{{ item[0]['dbname'] }}.*:ALL"
     append_privs: yes
     state: present
+  when: pdns_mysql_databases_credentials
   with_subelements:
     - "{{ pdns_backends | combine(pdns_mysql_databases_credentials, recursive=True) }}"
     - priv_host
     - skip_missing: yes
 
+# TODO: add support for file socket connections instead of host/port combos
 - name: Check if the MySQL databases are empty
   command: >
     mysql --user="{{ item['value']['user'] }}" --password="{{ item['value']['password'] }}"
-    --host="{{ item['value']['host'] }}" --port "{{ item['value']['port'] | default('3306') }}" --batch --skip-column-names
+    --host="{{ item['value']['host'] | default('localhost') }}" --port "{{ item['value']['port'] | default('3306') }}" --batch --skip-column-names
     --execute="SELECT COUNT(DISTINCT table_name) FROM information_schema.columns WHERE table_schema = '{{ item['value']['dbname'] }}'"
   when: item.key.split(':')[0] == 'gmysql'
   with_dict: "{{ pdns_backends }}"
   register: _pdns_check_mysql_db
-  no_log: True
+    #  no_log: True
   changed_when: False
 
 - name: Determine location of the SQL file
@@ -64,15 +66,16 @@
   set_fact:
     pdns_mysql_schema_file_to_use: "{% if pdns_mysql_schema_file | length == 0 %}{{ pdns_mysql_schema_file_detected.stdout }}{% else %}{{ pdns_mysql_schema_file }}{% endif %}"
 
+# TODO: add support for file socket connections instead of host/port combos
 - name: Import the PowerDNS MySQL schema
   mysql_db:
     login_user: "{{ item['item']['value']['user'] }}"
     login_password: "{{ item['item']['value']['password'] }}"
-    login_host: "{{ item['item']['value']['host'] }}"
+    login_host: "{{ item['item']['value']['host'] | default('localhost') }}"
     login_port: "{{ item['item']['port'] | default('3306') }}"
     name: "{{ item.item['value']['dbname'] }}"
     state: import
     target: "{{ pdns_mysql_schema_file_to_use }}"
   no_log: True
-  when: "item['item']['key'].split(':')[0] == 'gmysql' and item['stdout'] == '0'"
+  when: "item['item']['key'].split(':')[0] == 'gmysql' and item['stdout'] == '0' and pdns_mysql_schema_load"
   with_items: "{{ _pdns_check_mysql_db['results'] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     - config
 
 - include_tasks: database-mysql.yml
-  when: "pdns_mysql_databases_credentials | length > 0"
+  when: "'gmysql' in pdns_backends"
   tags:
     - db
     - mysql

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -4,7 +4,7 @@
     name: pdns_can_network_connect_db
     state: yes
     persistent: yes
-  when: "pdns_mysql_databases_credentials | length > 0"
+  when: "'gmysql' in pdns_backends"
 
 - name: allow pdns to bind to udp high ports
   seport:


### PR DESCRIPTION
When we have a gmysql backend, we do still want to run most of the Mysql-specific setup, apart from the db/user creation. Previously, the pdns_mysql_databases_credentials var was used to trigger this.

However, pdns_mysql_databases_credentials contains the database 'root' credentials, and is used when creating the DB/User. Sometimes we don't need/have the root credentials, as the db might be externally provisioned. Yet we still need the mysql-backend dependencies, and might (optionally) also load the default schema.

This PR looks at the defined backends, and will trigger the MySQL tasks if it detects a gmysql backend.

Additionally, we introduce a boolean parameter `pdns_mysql_schema_load` (default true) so we can allow the user to optionally skip loading the default schema.

Lastly, it adds a default host of "localhost" if not specified in the `pdns_backends['gmysql']` struct. TODO for later: if host isn't defined, use the unix socket instead of localhost.