### PR TITLE
Update pdns-master: replace deprecated attributes and replace bionic with focal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
           - pdns-master
           - pdns-os-repos
           - systemd-no-overrides
+      fail-fast: false
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/molecule/pdns-master/molecule.yml
+++ b/molecule/pdns-master/molecule.yml
@@ -25,15 +25,26 @@ platforms:
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
 
-  - name: ubuntu-1804
+  - name: ubuntu-2004
     groups: ["pdns"]
-    image: ubuntu:18.04
+    image: ubuntu:20.04
+    tmpfs:
+      - /run
+      - /tmp
     dockerfile_tpl: debian-systemd
 
   - name: debian-10
     groups: ["pdns"]
     image: debian:10
+    privileged: True
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
     dockerfile_tpl: debian-systemd
+    environment: { container: docker }
 
   # In order to run the tests we need
   # a MySQL container to be up & running

--- a/molecule/pdns-os-repos/converge.yml
+++ b/molecule/pdns-os-repos/converge.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: pdns
   vars_files:
-    - ../resources/vars/pdns-common.yml
+    - ../resources/vars/pdns-os-repos.yml
     - ../resources/vars/pdns-backends.yml
   roles:
     - { role: powerdns.pdns }

--- a/molecule/resources/vars/pdns-common.yml
+++ b/molecule/resources/vars/pdns-common.yml
@@ -6,8 +6,8 @@
 
 pdns_config:
 
-  # Turns on master operations
-  master: true
+  # Turns on primary operations
+  primary: true
 
   # Listen Address
   local-address: "127.0.0.1"

--- a/molecule/resources/vars/pdns-no-overrides.yml
+++ b/molecule/resources/vars/pdns-no-overrides.yml
@@ -6,8 +6,8 @@
 
 pdns_config:
 
-  # Turns on master operations
-  master: true
+  # Turns on primary operations
+  primary: true
 
   # Listen Address
   local-address: "127.0.0.1"

--- a/molecule/resources/vars/pdns-os-repos.yml
+++ b/molecule/resources/vars/pdns-os-repos.yml
@@ -1,5 +1,26 @@
 ---
 
 ##
-# No special things
+# PowerDNS Configuration
 ##
+
+pdns_config:
+
+  # Turns on master operations
+  master: true
+
+  # Listen Address
+  local-address: "127.0.0.1"
+  local-port: "53"
+
+  # API Configuration
+  api: yes
+  api-key: "powerdns"
+
+  # Embedded webserver
+  webserver: yes
+  webserver-address: "0.0.0.0"
+  webserver-port: "8001"
+
+pdns_service_overrides:
+  LimitCORE: infinity


### PR DESCRIPTION
Update molecules:

- Replace deprecated attribute `master` with `primary` as the former is no longer supported in master. Keep old attributes for test `pdns-no-repos` as it installs a very old version of `pdns`.
- Replace Ubuntu Bionic with Ubuntu Focal for `pdns-master`

Added tag to continue the tests even if one of the combinations fails.
