### PR TITLE
Fix test pdns-os-repos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
       fail-fast: false
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install dependencies

--- a/molecule/pdns-os-repos/molecule.yml
+++ b/molecule/pdns-os-repos/molecule.yml
@@ -10,6 +10,19 @@ dependency:
   name: galaxy
 
 platforms:
+  - name: debian-10
+    groups: ["pdns"]
+    image: debian:10
+    privileged: True
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    dockerfile_tpl: debian-systemd
+    environment: { container: docker }
+
   - name: debian-11
     groups: ["pdns"]
     image: debian:11
@@ -31,6 +44,14 @@ platforms:
   - name: ubuntu-2004
     groups: ["pdns"]
     image: ubuntu:20.04
+    tmpfs:
+      - /run
+      - /tmp
+    dockerfile_tpl: debian-systemd
+
+  - name: ubuntu-2204
+    groups: ["pdns"]
+    image: ubuntu:22.04
     tmpfs:
       - /run
       - /tmp

--- a/molecule/resources/Dockerfile.debian-systemd.j2
+++ b/molecule/resources/Dockerfile.debian-systemd.j2
@@ -22,4 +22,4 @@ VOLUME [ "/sys/fs/cgroup" ]
 
 CMD ["/sbin/init"]
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python python3 sudo bash net-tools ca-certificates && apt-get clean; fi
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python3 sudo bash net-tools ca-certificates && apt-get clean; fi

--- a/molecule/resources/host_vars/debian-10.yml
+++ b/molecule/resources/host_vars/debian-10.yml
@@ -2,3 +2,6 @@
 
 ansible_python_interpreter: "/usr/bin/python3"
 
+# pdns-os-repos: debian-10 installs auth 4.1.6
+_pdns_config_legacy:
+  master: true

--- a/molecule/resources/host_vars/debian-11.yml
+++ b/molecule/resources/host_vars/debian-11.yml
@@ -1,0 +1,5 @@
+---
+
+# pdns-os-repos: debian-11 installs auth 4.4.1
+_pdns_config_legacy:
+  master: true

--- a/molecule/resources/host_vars/ubuntu-2004.yml
+++ b/molecule/resources/host_vars/ubuntu-2004.yml
@@ -1,3 +1,7 @@
 ---
 
 ansible_python_interpreter: "/usr/bin/python3"
+
+# pdns-os-repos: ubuntu-20.04 installs auth 4.4.1
+_pdns_config_legacy:
+  master: true

--- a/molecule/resources/vars/pdns-os-repos.yml
+++ b/molecule/resources/vars/pdns-os-repos.yml
@@ -4,10 +4,7 @@
 # PowerDNS Configuration
 ##
 
-pdns_config:
-
-  # Turns on master operations
-  primary: true
+_pdns_config_base:
 
   # Listen Address
   local-address: "127.0.0.1"
@@ -21,6 +18,12 @@ pdns_config:
   webserver: yes
   webserver-address: "0.0.0.0"
   webserver-port: "8001"
+
+# Turns on master operations
+_pdns_config_primary:
+  primary: true
+
+pdns_config: "{{ _pdns_config_base | combine(_pdns_config_legacy | default(_pdns_config_primary), recursive=True) }}"
 
 pdns_service_overrides:
   LimitCORE: infinity

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -9,7 +9,6 @@ default_pdns_debug_symbols_package_name: "pdns-server-dbg"
 # Packages needed to install MySQL
 pdns_mysql_packages:
   - default-mysql-client
-  - python-mysqldb
   - python3-mysqldb
 
 # List of PowerDNS Authoritative Server Backends packages on Debian


### PR DESCRIPTION
Some of the OSs used for the test `pdns-os-repos`, install older versions of Auth that use legacy terms/attributes no longer supported in recent versions.

This PR is an attempt to keep running the test for OSs that are still under support but that install EOL versions of Auth by default alongside the ones that install newer versions.

Of course, it is always simpler to just remove from the test OSs that install no supported versions of Auth and just close this PR.
