### PR TITLE
Add missing packages on RHEL family to allow SElinux works correctly.

### DIFF
--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -1,26 +1,24 @@
 ---
-
 - block:
+    - name: Install epel-release on CentOS
+      yum:
+        name: epel-release
+        state: present
+      when: ansible_distribution in [ 'CentOS', 'Rocky', 'AlmaLinux' ]
 
-  - name: Install epel-release on CentOS
-    yum:
-      name: epel-release
-      state: present
-    when: ansible_distribution in [ 'CentOS', 'Rocky', 'AlmaLinux' ]
+    - name: Install epel-release on RHEL
+      package:
+        name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+        state: present
+      when: ansible_distribution in [ 'RedHat' ]
 
-  - name: Install epel-release on RHEL
-    package:
-      name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-      state: present
-    when: ansible_distribution in [ 'RedHat' ]
-
-  - name: Install epel-release and hostname on OracleLinux
-    package:
-      name: 
-      - "oracle-epel-release-el{{ ansible_distribution_major_version }}"
-      - hostname
-      state: present
-    when: ansible_distribution in [ 'OracleLinux' ]
+    - name: Install epel-release and hostname on OracleLinux
+      package:
+        name:
+          - "oracle-epel-release-el{{ ansible_distribution_major_version }}"
+          - hostname
+        state: present
+      when: ansible_distribution in [ 'OracleLinux' ]
 
   when: pdns_install_epel
 
@@ -31,6 +29,14 @@
   when:
     - ansible_distribution in [ 'CentOS', 'Rocky', 'AlmaLinux' ]
     - ansible_distribution_major_version | int < 8
+
+- name: Install policycoreutils-python-utils to manage an SELinux environment.
+  package:
+    name: policycoreutils-python-utils
+    state: present
+  when:
+    - ansible_distribution in [ 'RedHat' 'CentOS', 'Rocky', 'AlmaLinux' ]
+    - ansible_distribution_major_version | int > 9
 
 - name: Add the PowerDNS YUM Repository
   yum_repository:


### PR DESCRIPTION
Without the **policycoreutils-python-utils** package and using a minimal AlmaLinux 9 (almost 100% sure that it will happen with others distros too) the [SElinux tasks](https://github.com/PowerDNS/pdns-ansible/blob/master/tasks/selinux.yml) fail with this error:



```
"msg": "Failed to import the required Python library (policycoreutils-python) on 990-pdns-auth-02.test.mydomain.com's 
Python /usr/bin/python3. Please read the module documentation and install it in the appropriate location. 
If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"
```

installing the **policycoreutils-python-utils** and all the dependence fix the issue.
