### PR TITLE
change default for SQLite 3 database backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ in the location specified by the `database_name` variable.
   roles:
     - { role: PowerDNS.pdns }
   vars:
-    database_name: '/var/lib/powerdns/db.sqlite'
+    database_name: '/var/lib/powerdns/pdns.sqlite3'
     pdns_config:
       master: true
       slave: false

--- a/molecule/resources/tests/backend-sqlite/test_backend_sqlite.py
+++ b/molecule/resources/tests/backend-sqlite/test_backend_sqlite.py
@@ -15,7 +15,7 @@ def test_package(host):
 
 
 def test_database_exists(host):
-    f = host.file('/var/lib/powerdns/pdns.db')
+    f = host.file('/var/lib/powerdns/pdns.sqlite3')
     user = 'pdns'
     if host.system_info.distribution.lower() in archlinux_os:
         user = 'powerdns'

--- a/molecule/resources/vars/pdns-backends.yml
+++ b/molecule/resources/vars/pdns-backends.yml
@@ -6,7 +6,7 @@
 
 pdns_backends:
   gsqlite3:
-    database: /var/lib/powerdns/pdns.db
+    database: /var/lib/powerdns/pdns.sqlite3
     dnssec: yes
   gmysql:
     host: "mysql"                                          # This is relying on Docker's service discovery
@@ -15,7 +15,7 @@ pdns_backends:
     password: pdns
 
 pdns_sqlite_databases_locations:
-  - '/var/lib/powerdns/pdns.db'
+  - '/var/lib/powerdns/pdns.sqlite3'
 
 pdns_mysql_databases_credentials:
   gmysql:


### PR DESCRIPTION
Change default of SQLite 3 database backend location according to the default in documentation.