### PR TITLE
GH Actions: fix issues with CI

### DIFF
--- a/molecule/pdns-47/molecule.yml
+++ b/molecule/pdns-47/molecule.yml
@@ -10,9 +10,9 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
+  - name: oraclelinux-7
     groups: ["pdns"]
-    image: centos:7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: rockylinux-8

--- a/molecule/pdns-48/molecule.yml
+++ b/molecule/pdns-48/molecule.yml
@@ -10,9 +10,9 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
+  - name: oraclelinux-7
     groups: ["pdns"]
-    image: centos:7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: rockylinux-8

--- a/molecule/pdns-49/molecule.yml
+++ b/molecule/pdns-49/molecule.yml
@@ -10,9 +10,9 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
+  - name: oraclelinux-7
     groups: ["pdns"]
-    image: centos:7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: rockylinux-8

--- a/molecule/pdns-master/molecule.yml
+++ b/molecule/pdns-master/molecule.yml
@@ -10,9 +10,9 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
+  - name: oraclelinux-7
     groups: ["pdns"]
-    image: centos:7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: rockylinux-8

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -60,5 +60,5 @@
         privileged: "yes"
         volumes:
           # Mount the cgroups fs to allow SystemD to run into the containers
-          - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
+          - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
       with_items: "{{ molecule_platform_instances }}"

--- a/molecule/resources/tests/backend-mysql/test_backend_mysql.py
+++ b/molecule/resources/tests/backend-mysql/test_backend_mysql.py
@@ -31,9 +31,11 @@ def test_config(host):
 def test_database_tables(host):
     dbname = host.check_output('hostname -s').replace('.', '_')
 
-    cmd = host.run("mysql --user=\"pdns\" --password=\"pdns\" --host=\"mysql\" " +
-                          "--batch --skip-column-names " +
-                          "--execute=\"SELECT DISTINCT table_name FROM information_schema.columns WHERE table_schema = '%s'\"" % dbname)
+    mysql_cmd = 'mariadb --skip-ssl-verify-server-cert' if host.system_info.distribution.lower() in archlinux_os else 'mysql'
+
+    cmd = host.run(
+        f'{mysql_cmd} --user="pdns" --password="pdns" --host="mysql" --batch --skip-column-names --execute="SELECT DISTINCT table_name FROM information_schema.columns WHERE table_schema = \'{dbname}\'"'
+    )
 
     for table in [ 'domains', 'records', 'supermasters', 'comments',
             'domainmetadata', 'cryptokeys', 'tsigkeys' ]:

--- a/molecule/resources/tests/repo-master/test_repo_master.py
+++ b/molecule/resources/tests/repo-master/test_repo_master.py
@@ -40,5 +40,5 @@ def test_repo_pinning_file(host):
 def test_pdns_version(host):
     cmd = host.run('/usr/sbin/pdns_server --version')
 
-    assert 'PowerDNS Authoritative Server' in cmd.stderr
-    assert 'master' in cmd.stderr
+    assert 'PowerDNS Authoritative Server' in cmd.stderr or 'PowerDNS Authoritative Server' in cmd.stdout
+    assert 'master' in cmd.stderr or 'master' in cmd.stdout

--- a/molecule/systemd-no-overrides/molecule.yml
+++ b/molecule/systemd-no-overrides/molecule.yml
@@ -13,11 +13,23 @@ platforms:
   - name: debian-10
     groups: ["pdns"]
     image: debian:10
+    privileged: True
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
     dockerfile_tpl: debian-systemd
+    environment: { container: docker }
+
 
   - name: ubuntu-2004
     groups: ["pdns"]
     image: ubuntu:20.04
+    tmpfs:
+      - /run
+      - /tmp
     dockerfile_tpl: debian-systemd
 
 provisioner:

--- a/tasks/database-mysql.yml
+++ b/tasks/database-mysql.yml
@@ -35,10 +35,10 @@
     - skip_missing: yes
 
 - name: Check if the MySQL databases are empty
-  command: >
-    mysql --user="{{ item['value']['user'] }}" --password="{{ item['value']['password'] }}"
-    --host="{{ item['value']['host'] }}" --port "{{ item['value']['port'] | default('3306') }}" --batch --skip-column-names
-    --execute="SELECT COUNT(DISTINCT table_name) FROM information_schema.columns WHERE table_schema = '{{ item['value']['dbname'] }}'"
+  shell: |-
+    {{ pdns_backends_mysql_cmd | default('mysql') }} --user="{{ item['value']['user'] }}" --password="{{ item['value']['password'] }}" \
+      --host="{{ item['value']['host'] }}" --port "{{ item['value']['port'] | default('3306') }}" --batch --skip-column-names \
+      --execute="SELECT COUNT(DISTINCT table_name) FROM information_schema.columns WHERE table_schema = '{{ item['value']['dbname'] }}'"
   when: item.key.split(':')[0] == 'gmysql'
   with_dict: "{{ pdns_backends }}"
   register: _pdns_check_mysql_db
@@ -64,15 +64,11 @@
   set_fact:
     pdns_mysql_schema_file_to_use: "{% if pdns_mysql_schema_file | length == 0 %}{{ pdns_mysql_schema_file_detected.stdout }}{% else %}{{ pdns_mysql_schema_file }}{% endif %}"
 
+
 - name: Import the PowerDNS MySQL schema
-  mysql_db:
-    login_user: "{{ item['item']['value']['user'] }}"
-    login_password: "{{ item['item']['value']['password'] }}"
-    login_host: "{{ item['item']['value']['host'] }}"
-    login_port: "{{ item['item']['port'] | default('3306') }}"
-    name: "{{ item.item['value']['dbname'] }}"
-    state: import
-    target: "{{ pdns_mysql_schema_file_to_use }}"
+  shell: |-
+    {{ pdns_backends_mysql_cmd | default('mysql') }} --user="{{ item['item']['value']['user'] }}" --password="{{ item['item']['value']['password'] }}" --host="{{ item['item']['value']['host'] }}" \
+      --port="{{ item['item']['port'] | default('3306') }}" "{{ item.item['value']['dbname'] }}" < "{{ pdns_mysql_schema_file_to_use }}"
   no_log: True
   when: "item['item']['key'].split(':')[0] == 'gmysql' and item['stdout'] == '0'"
   with_items: "{{ _pdns_check_mysql_db['results'] }}"

--- a/tasks/inspect.yml
+++ b/tasks/inspect.yml
@@ -2,7 +2,7 @@
 
 - name: Obtain the version of the running PowerDNS instance
   shell: |
-    pdns_server --version 2>&1 | awk '/PowerDNS Authoritative/{print $7}'
+    pdns_server --version 2>&1 | grep -o "PowerDNS Authoritative Server.*" | awk '{print $4}'
   register: _pdns_version
   check_mode: no
   changed_when: False

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,4 @@ molecule-plugins[docker]==23.4.1
 molecule-plugins[lint]==23.4.1
 molecule==5.1.0
 pytest-testinfra==8.1.0
-docker==6.1.3
+docker==7.1.0

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -9,6 +9,9 @@ default_pdns_backends_packages: {}
 # The directory where the PowerDNS configuration is located
 default_pdns_config_dir: '/etc/powerdns'
 
+# Change the default mysql client to mariabd "--skip-ssl-verify-server-cert"
+pdns_backends_mysql_cmd: 'mariadb --skip-ssl-verify-server-cert'
+
 # Packages to install for MySQL support
 pdns_mysql_packages:
   - python-pymysql


### PR DESCRIPTION
Included in this PR are fixes for:

- Version of `docker-py` set to 7.1.0. Older versions require a specific version of `requests` to work (see [here](https://github.com/docker/docker-py/issues/3256)
- Move from tests from`centos:7` to `oraclelinux:7`
- Adapt tests to comply with newer versions of auth that show a different string for `pdns_server --version` and also through stdout instead of stderr.
- Skip SSL validation for the `mysql` client in `archlinux`
- Mount `/sys/fs/cgroups` as `rw` to overcome the error that made containers fail after starting: `Failed to create /actions_job/b23bdd0759a907717ae61975e6bf5b5044ae8f9dee961e93a4c108e30868f395/init.scope control group: Read-only file system`
