### PR TITLE
Removed EOL targets RHEL-7 and Debian-10. Added Debian 11 and 12 and Ubuntu-24

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,16 +11,17 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 7
-        - 8
+        - "8"
+        - "9"
     - name: Debian
       versions:
-        - stretch
-        - buster
+        - bullseye
+        - bookworm
     - name: Ubuntu
       versions:
-        - bionic
         - focal
+        - jammy
+        - noble
     - name: ArchLinux
   galaxy_tags:
     - system

--- a/molecule/pdns-47/molecule.yml
+++ b/molecule/pdns-47/molecule.yml
@@ -10,11 +10,6 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: oraclelinux-7
-    groups: ["pdns"]
-    image: oraclelinux:7
-    dockerfile_tpl: centos-systemd
-
   - name: rockylinux-8
     groups: ["pdns"]
     image: rockylinux:8
@@ -53,9 +48,17 @@ platforms:
       - /tmp
     dockerfile_tpl: debian-systemd
 
-  - name: debian-10
+  - name: ubuntu-2204
     groups: ["pdns"]
-    image: debian:10
+    image: ubuntu:22.04
+    tmpfs:
+      - /run
+      - /tmp
+    dockerfile_tpl: debian-systemd
+
+  - name: debian-11
+    groups: ["pdns"]
+    image: debian:11
     privileged: True
     volume_mounts:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"

--- a/molecule/pdns-48/molecule.yml
+++ b/molecule/pdns-48/molecule.yml
@@ -10,11 +10,6 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: oraclelinux-7
-    groups: ["pdns"]
-    image: oraclelinux:7
-    dockerfile_tpl: centos-systemd
-
   - name: rockylinux-8
     groups: ["pdns"]
     image: rockylinux:8
@@ -53,9 +48,30 @@ platforms:
       - /tmp
     dockerfile_tpl: debian-systemd
 
-  - name: debian-10
+  - name: ubuntu-2204
     groups: ["pdns"]
-    image: debian:10
+    image: ubuntu:22.04
+    tmpfs:
+      - /run
+      - /tmp
+    dockerfile_tpl: debian-systemd
+
+  - name: debian-11
+    groups: ["pdns"]
+    image: debian:11
+    privileged: True
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    dockerfile_tpl: debian-systemd
+    environment: { container: docker }
+
+  - name: debian-12
+    groups: ["pdns"]
+    image: debian:12
     privileged: True
     volume_mounts:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"

--- a/molecule/pdns-49/molecule.yml
+++ b/molecule/pdns-49/molecule.yml
@@ -10,11 +10,6 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: oraclelinux-7
-    groups: ["pdns"]
-    image: oraclelinux:7
-    dockerfile_tpl: centos-systemd
-
   - name: rockylinux-8
     groups: ["pdns"]
     image: rockylinux:8
@@ -53,9 +48,38 @@ platforms:
       - /tmp
     dockerfile_tpl: debian-systemd
 
-  - name: debian-10
+  - name: ubuntu-2204
     groups: ["pdns"]
-    image: debian:10
+    image: ubuntu:22.04
+    tmpfs:
+      - /run
+      - /tmp
+    dockerfile_tpl: debian-systemd
+
+  - name: ubuntu-2404
+    groups: ["pdns"]
+    image: ubuntu:24.04
+    tmpfs:
+      - /run
+      - /tmp
+    dockerfile_tpl: debian-systemd
+
+  - name: debian-11
+    groups: ["pdns"]
+    image: debian:11
+    privileged: True
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    dockerfile_tpl: debian-systemd
+    environment: { container: docker }
+
+  - name: debian-12
+    groups: ["pdns"]
+    image: debian:12
     privileged: True
     volume_mounts:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"

--- a/molecule/pdns-master/molecule.yml
+++ b/molecule/pdns-master/molecule.yml
@@ -10,11 +10,6 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: oraclelinux-7
-    groups: ["pdns"]
-    image: oraclelinux:7
-    dockerfile_tpl: centos-systemd
-
   - name: rockylinux-8
     groups: ["pdns"]
     image: rockylinux:8
@@ -53,9 +48,38 @@ platforms:
       - /tmp
     dockerfile_tpl: debian-systemd
 
-  - name: debian-10
+  - name: ubuntu-2204
     groups: ["pdns"]
-    image: debian:10
+    image: ubuntu:22.04
+    tmpfs:
+      - /run
+      - /tmp
+    dockerfile_tpl: debian-systemd
+
+  - name: ubuntu-2404
+    groups: ["pdns"]
+    image: ubuntu:24.04
+    tmpfs:
+      - /run
+      - /tmp
+    dockerfile_tpl: debian-systemd
+
+  - name: debian-11
+    groups: ["pdns"]
+    image: debian:11
+    privileged: True
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    dockerfile_tpl: debian-systemd
+    environment: { container: docker }
+
+  - name: debian-12
+    groups: ["pdns"]
+    image: debian:12
     privileged: True
     volume_mounts:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"

--- a/molecule/pdns-os-repos/molecule.yml
+++ b/molecule/pdns-os-repos/molecule.yml
@@ -10,9 +10,9 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: debian-10
+  - name: debian-11
     groups: ["pdns"]
-    image: debian:10
+    image: debian:11
     privileged: True
     volume_mounts:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
@@ -23,9 +23,9 @@ platforms:
     dockerfile_tpl: debian-systemd
     environment: { container: docker }
 
-  - name: debian-11
+  - name: debian-12
     groups: ["pdns"]
-    image: debian:11
+    image: debian:12
     privileged: True
     volume_mounts:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
@@ -52,6 +52,14 @@ platforms:
   - name: ubuntu-2204
     groups: ["pdns"]
     image: ubuntu:22.04
+    tmpfs:
+      - /run
+      - /tmp
+    dockerfile_tpl: debian-systemd
+
+  - name: ubuntu-2404
+    groups: ["pdns"]
+    image: ubuntu:24.04
     tmpfs:
       - /run
       - /tmp

--- a/molecule/systemd-no-overrides/molecule.yml
+++ b/molecule/systemd-no-overrides/molecule.yml
@@ -10,9 +10,9 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: debian-10
+  - name: debian-11
     groups: ["pdns"]
-    image: debian:10
+    image: debian:11
     privileged: True
     volume_mounts:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
@@ -23,10 +23,38 @@ platforms:
     dockerfile_tpl: debian-systemd
     environment: { container: docker }
 
+  - name: debian-12
+    groups: ["pdns"]
+    image: debian:12
+    privileged: True
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    dockerfile_tpl: debian-systemd
+    environment: { container: docker }
 
   - name: ubuntu-2004
     groups: ["pdns"]
     image: ubuntu:20.04
+    tmpfs:
+      - /run
+      - /tmp
+    dockerfile_tpl: debian-systemd
+
+  - name: ubuntu-2204
+    groups: ["pdns"]
+    image: ubuntu:22.04
+    tmpfs:
+      - /run
+      - /tmp
+    dockerfile_tpl: debian-systemd
+
+  - name: ubuntu-2404
+    groups: ["pdns"]
+    image: ubuntu:24.04
     tmpfs:
       - /run
       - /tmp


### PR DESCRIPTION
Fixes errors in CI.

Platforms removed:

- `oraclelinux-7`
- `debian-10`

Added:

- `debian-11`
- `debian-12`
- `ubuntu-24.04`