### PR TITLE
CI tests: upgraded version of molecule and ansible-core packages

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+---
+skip_list:
+  - '306'  # [306] Shells that use pipes should set the pipefail option
+  - 'args' # [args] throws a warning on community.docker.docker_container for a correct attribute (cgroupns_mode)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,15 +6,22 @@ on:
     - cron: '33 5 * * 0'
 
 jobs:
+  Lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@main
   Tests:
     name: Test role on different ansible versions
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         ansible:
-          - "2.12"
-          - "2.13"
           - "2.14"
+          - "2.15"
+          - "2.16"
         scenario:
           - pdns-47
           - pdns-48
@@ -22,14 +29,13 @@ jobs:
           - pdns-master
           - pdns-os-repos
           - systemd-no-overrides
-      fail-fast: false
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - name: Install python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/molecule/pdns-47/converge.yml
+++ b/molecule/pdns-47/converge.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: pdns
+- name: PDNS 4.7
+  hosts: pdns
   vars_files:
     - ../resources/vars/pdns-common.yml
     - ../resources/vars/pdns-repo-47.yml

--- a/molecule/pdns-47/molecule.yml
+++ b/molecule/pdns-47/molecule.yml
@@ -119,4 +119,3 @@ verifier:
     - ../backend-sqlite/
     - ../backend-mysql/
     - ../systemd-override/
-

--- a/molecule/pdns-48/converge.yml
+++ b/molecule/pdns-48/converge.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: pdns
+- name: PDNS 4.8
+  hosts: pdns
   vars_files:
     - ../resources/vars/pdns-common.yml
     - ../resources/vars/pdns-repo-48.yml

--- a/molecule/pdns-48/molecule.yml
+++ b/molecule/pdns-48/molecule.yml
@@ -132,4 +132,3 @@ verifier:
     - ../backend-sqlite/
     - ../backend-mysql/
     - ../systemd-override/
-

--- a/molecule/pdns-49/converge.yml
+++ b/molecule/pdns-49/converge.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: pdns
+- name: PDNS 4.9
+  hosts: pdns
   vars_files:
     - ../resources/vars/pdns-common.yml
     - ../resources/vars/pdns-repo-49.yml

--- a/molecule/pdns-49/molecule.yml
+++ b/molecule/pdns-49/molecule.yml
@@ -140,4 +140,3 @@ verifier:
     - ../backend-sqlite/
     - ../backend-mysql/
     - ../systemd-override/
-

--- a/molecule/pdns-master/converge.yml
+++ b/molecule/pdns-master/converge.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: pdns
+- name: PDNS master
+  hosts: pdns
   vars_files:
     - ../resources/vars/pdns-common.yml
     - ../resources/vars/pdns-repo-master.yml

--- a/molecule/pdns-master/molecule.yml
+++ b/molecule/pdns-master/molecule.yml
@@ -137,4 +137,3 @@ verifier:
     - ../backend-sqlite/
     - ../backend-mysql/
     - ../systemd-override/
-

--- a/molecule/pdns-os-repos/converge.yml
+++ b/molecule/pdns-os-repos/converge.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: pdns
+- name: PDNS OS Repos
+  hosts: pdns
   vars_files:
     - ../resources/vars/pdns-os-repos.yml
     - ../resources/vars/pdns-backends.yml

--- a/molecule/pdns-os-repos/molecule.yml
+++ b/molecule/pdns-os-repos/molecule.yml
@@ -111,4 +111,3 @@ verifier:
     - ../systemd-override/
     - ../backend-sqlite/
     - ../backend-mysql/
-

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -61,4 +61,5 @@
         volumes:
           # Mount the cgroups fs to allow SystemD to run into the containers
           - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+        cgroupns_mode: host
       with_items: "{{ molecule_platform_instances }}"

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -8,26 +8,30 @@
     - vars/molecule.yml
   tasks:
 
-    - set_fact:
+    - name: Get list of service instances
+      ansible.builtin.set_fact:
         molecule_service_instances: "{{ molecule_yml.platforms | selectattr('is_service', 'defined') | selectattr('is_service') | list }}"
-    - set_fact:
+
+    - name: Get list of platform instances
+      ansible.builtin.set_fact:
         molecule_platform_instances: "{{ molecule_yml.platforms | difference(molecule_service_instances) }}"
 
     - name: Create Dockerfiles from image names
-      template:
+      ansible.builtin.template:
         src: "Dockerfile.{{ item.dockerfile_tpl | default('default') }}.j2"
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+        mode: '0644'
       with_items: "{{ molecule_platform_instances }}"
       register: platforms
 
     - name: Discover local Docker images
-      docker_image_info:
+      community.docker.docker_image_info:
         name: "molecule_pdns/{{ item.item.name }}"
       with_items: "{{ platforms.results }}"
       register: docker_images
 
     - name: Build an Ansible compatible image
-      docker_image:
+      community.docker.docker_image:
         source: build
         name: "molecule_pdns/{{ item.item.image }}"
         build:
@@ -37,7 +41,7 @@
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 
     - name: Create molecule instance(s)
-      docker_container:
+      community.docker.docker_container:
         name: "{{ item.name }}"
         hostname: "{{ item.name }}"
         image: "{{ item.image }}"
@@ -49,7 +53,7 @@
       with_items: "{{ molecule_service_instances }}"
 
     - name: Create the required Services instance(s)
-      docker_container:
+      community.docker.docker_container:
         name: "{{ item.name }}"
         hostname: "{{ item.name }}"
         image: "molecule_pdns/{{ item.image }}"

--- a/molecule/resources/destroy.yml
+++ b/molecule/resources/destroy.yml
@@ -8,7 +8,7 @@
     - vars/molecule.yml
   tasks:
     - name: Destroy the target Platforms instance(s)
-      docker_container:
+      community.docker.docker_container:
         name: "{{ item.name }}"
         state: absent
         force_kill: "{{ item.force_kill | default(True) }}"

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -6,28 +6,29 @@
     # Make sure the default MySQL and SQLite
     # schemas are installed in /usr/share/doc/
     - name: Disable the YUM 'nodocs' option
-      lineinfile:
+      ansible.builtin.lineinfile:
         line: tsflags=nodocs
         dest: /etc/yum.conf
         state: absent
       when: ansible_pkg_mgr == 'yum'
 
     - name: Disable the APT 'nodoc' option
-      lineinfile:
+      ansible.builtin.lineinfile:
         line: path-exclude=/usr/share/doc/*
         dest: /etc/dpkg/dpkg.cfg.d/excludes
         state: absent
 
     # Install rsyslog to capture the PDNS log messages
     # when the service is not managed by systemd
-    - block:
+    - name: Install rsyslog
+      when: ansible_service_mgr != 'systemd'
+      block:
         - name: Install rsyslog
-          package:
+          ansible.builtin.package:
             name: rsyslog
             state: present
 
         - name: Start rsyslog
-          service:
+          ansible.builtin.service:
             name: rsyslog
             state: started
-      when: ansible_service_mgr != 'systemd'

--- a/molecule/resources/vars/molecule.yml
+++ b/molecule/resources/vars/molecule.yml
@@ -2,6 +2,6 @@
 molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
 molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
 molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
-role-file: requirements.yml
-requirements-file: requirements.yml
+role_file: requirements.yml
+requirements_file: requirements.yml
 molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"

--- a/molecule/systemd-no-overrides/converge.yml
+++ b/molecule/systemd-no-overrides/converge.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: pdns
+- name: PDNS SystemD no-overrides
+  hosts: pdns
   vars_files:
     - ../resources/vars/pdns-no-overrides.yml
   roles:

--- a/molecule/systemd-no-overrides/molecule.yml
+++ b/molecule/systemd-no-overrides/molecule.yml
@@ -93,4 +93,3 @@ verifier:
   additional_files_or_dirs:
     # path relative to 'directory'
     - ../systemd-no-override
-

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,33 +1,34 @@
 ---
-
-- block:
+- name: Set up systemd override
+  when: ansible_service_mgr == "systemd"
+  block:
 
   - name: Ensure the override directory exists (systemd)
-    file:
+    ansible.builtin.file:
       name: "/etc/systemd/system/{{ pdns_service_name }}.service.d"
       state: directory
       owner: root
       group: root
+      mode: 0755
 
   - name: Override the PowerDNS Authoritative Server unit (systemd)
-    template:
+    ansible.builtin.template:
       src: "override-service.systemd.conf.j2"
       dest: "/etc/systemd/system/{{ pdns_service_name }}.service.d/override.conf"
       owner: root
       group: root
+      mode: 0644
     register: _pdns_override_unit
     when: pdns_service_overrides | length > 0
 
   - name: Reload systemd
-    systemd:
+    ansible.builtin.systemd:
       daemon_reload: yes
     when: not pdns_disable_handlers
       and _pdns_override_unit.changed
 
-  when: ansible_service_mgr == "systemd"
-
 - name: Ensure that the PowerDNS configuration directory exists
-  file:
+  ansible.builtin.file:
     name: "{{ pdns_config_dir }}"
     state: directory
     owner: "{{ pdns_file_owner }}"
@@ -35,7 +36,7 @@
     mode: 0750
 
 - name: Generate the PowerDNS configuration
-  template:
+  ansible.builtin.template:
     src: pdns.conf.j2
     dest: "{{ pdns_config_dir }}/{{ pdns_config_file }}"
     owner: "{{ pdns_file_owner }}"
@@ -44,7 +45,7 @@
   register: _pdns_configuration
 
 - name: Ensure that the PowerDNS 'include-dir' directory exists
-  file:
+  ansible.builtin.file:
     name: "{{ pdns_config['include-dir'] }}"
     state: directory
     owner: "{{ pdns_file_owner }}"
@@ -53,7 +54,7 @@
   when: "pdns_config['include-dir'] is defined"
 
 - name: Restart PowerDNS
-  service:
+  ansible.builtin.service:
     name: "{{ pdns_service_name }}"
     state: restarted
     sleep: 1

--- a/tasks/database-lmdb.yml
+++ b/tasks/database-lmdb.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Ensure that the directories containing the PowerDNS LMDB databases exist
-  file:
+  ansible.builtin.file:
     name: "{{ item | dirname }}"
     owner: "{{ pdns_user }}"
     group: "{{ pdns_group }}"

--- a/tasks/database-mysql.yml
+++ b/tasks/database-mysql.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: Install the MySQL dependencies
-  package:
+  ansible.builtin.package:
     name: "{{ pdns_mysql_packages }}"
     state: present
 
 - name: Create the PowerDNS MySQL databases
-  mysql_db:
+  community.mysql.mysql_db:
     login_user: "{{ item['value']['priv_user'] }}"
     login_password: "{{ item['value']['priv_password'] }}"
     login_host: "{{ item['value']['host'] }}"
@@ -18,7 +18,7 @@
   with_dict: "{{ pdns_backends | combine(pdns_mysql_databases_credentials, recursive=True) }}"
 
 - name: Grant PowerDNS access to the MySQL databases
-  mysql_user:
+  community.mysql.mysql_user:
     login_user: "{{ item[0]['priv_user'] }}"
     login_password: "{{ item[0]['priv_password'] }}"
     login_host: "{{ item[0]['host'] }}"
@@ -35,8 +35,9 @@
     - skip_missing: yes
 
 - name: Check if the MySQL databases are empty
-  shell: |-
-    {{ pdns_backends_mysql_cmd | default('mysql') }} --user="{{ item['value']['user'] }}" --password="{{ item['value']['password'] }}" \
+  ansible.builtin.shell:
+    cmd: |-
+      {{ pdns_backends_mysql_cmd | default('mysql') }} --user="{{ item['value']['user'] }}" --password="{{ item['value']['password'] }}" \
       --host="{{ item['value']['host'] }}" --port "{{ item['value']['port'] | default('3306') }}" --batch --skip-column-names \
       --execute="SELECT COUNT(DISTINCT table_name) FROM information_schema.columns WHERE table_schema = '{{ item['value']['dbname'] }}'"
   when: item.key.split(':')[0] == 'gmysql'
@@ -46,7 +47,7 @@
   changed_when: False
 
 - name: Determine location of the SQL file
-  shell:
+  ansible.builtin.shell:
     cmd: |
       for p in /usr/share/doc/pdns-backend-mysql-{{ _pdns_running_version }}/schema.mysql.sql /usr/share/doc/pdns-backend-mysql/schema.mysql.sql /usr/share/pdns-backend-mysql/schema/schema.mysql.sql /usr/share/dbconfig-common/data/pdns-backend-mysql/install/mysql /usr/share/doc/powerdns/schema.mysql.sql /usr/share/doc/pdns/schema.mysql.sql; do
         if [ -f $p ]; then
@@ -61,14 +62,14 @@
   when: pdns_mysql_schema_file | length == 0
 
 - name: Set the schema file variable
-  set_fact:
+  ansible.builtin.set_fact:
     pdns_mysql_schema_file_to_use: "{% if pdns_mysql_schema_file | length == 0 %}{{ pdns_mysql_schema_file_detected.stdout }}{% else %}{{ pdns_mysql_schema_file }}{% endif %}"
 
-
 - name: Import the PowerDNS MySQL schema
-  shell: |-
+  ansible.builtin.shell: |-
     {{ pdns_backends_mysql_cmd | default('mysql') }} --user="{{ item['item']['value']['user'] }}" --password="{{ item['item']['value']['password'] }}" --host="{{ item['item']['value']['host'] }}" \
       --port="{{ item['item']['port'] | default('3306') }}" "{{ item.item['value']['dbname'] }}" < "{{ pdns_mysql_schema_file_to_use }}"
+  changed_when: True
   no_log: True
   when: "item['item']['key'].split(':')[0] == 'gmysql' and item['stdout'] == '0'"
   with_items: "{{ _pdns_check_mysql_db['results'] }}"

--- a/tasks/database-sqlite3.yml
+++ b/tasks/database-sqlite3.yml
@@ -1,19 +1,19 @@
 ---
 
 - name: Install the SQLite dependencies on RedHat
-  package:
+  ansible.builtin.package:
     name: sqlite
     state: present
   when: ansible_os_family == 'RedHat'
 
 - name: Install the SQLite dependencies on Debian
-  package:
+  ansible.builtin.package:
     name: sqlite3
     state: present
   when: ansible_os_family == 'Debian'
 
 - name: Ensure that the directories containing the PowerDNS SQLite databases exist
-  file:
+  ansible.builtin.file:
     name: "{{ item | dirname }}"
     owner: "{{ pdns_user }}"
     group: "{{ pdns_group }}"
@@ -22,7 +22,7 @@
   with_items: "{{ pdns_sqlite_databases_locations }}"
 
 - name: Determine location of the SQL file
-  shell:
+  ansible.builtin.shell:
     cmd: |
       for p in /usr/share/doc/pdns-backend-sqlite-{{ _pdns_running_version }}/schema.sql /usr/share/doc/pdns-backend-sqlite-{{ _pdns_running_version }}/schema.sqlite3.sql /usr/share/doc/pdns/schema.sqlite3.sql /usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql /usr/share/doc/pdns-backend-sqlite/schema.sqlite3.sql /usr/share/doc/powerdns/schema.sqlite3.sql; do
         if [ -f $p ]; then
@@ -37,17 +37,17 @@
   when: pdns_sqlite_schema_file | length == 0
 
 - name: Set the schema file variable
-  set_fact:
+  ansible.builtin.set_fact:
     pdns_sqlite_schema_file_to_use: "{% if pdns_sqlite_schema_file | length == 0 %}{{ pdns_sqlite_schema_file_detected.stdout }}{% else %}{{ pdns_sqlite_schema_file }}{% endif %}"
 
 - name: Create the PowerDNS SQLite databases
-  shell: "sqlite3 {{ item }} < {{ pdns_sqlite_schema_file_to_use }}"
+  ansible.builtin.shell: "sqlite3 {{ item }} < {{ pdns_sqlite_schema_file_to_use }}"
   args:
     creates: "{{ item }}"
   with_items: "{{ pdns_sqlite_databases_locations }}"
 
 - name: Check the PowerDNS SQLite databases permissions
-  file:
+  ansible.builtin.file:
     name: "{{ item }}"
     owner: "{{ pdns_user }}"
     group: "{{ pdns_group }}"

--- a/tasks/inspect.yml
+++ b/tasks/inspect.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: Obtain the version of the running PowerDNS instance
-  shell: |
+  ansible.builtin.shell: |
     pdns_server --version 2>&1 | grep -o "PowerDNS Authoritative Server.*" | awk '{print $4}'
   register: _pdns_version
   check_mode: no
   changed_when: False
 
 - name: Export the running PowerDNS instance version to a variable
-  set_fact:
+  ansible.builtin.set_fact:
     _pdns_running_version: "{{ _pdns_version['stdout'] | regex_replace('-[.\\d\\w]+$', '') }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,32 +1,30 @@
 ---
-
-- block:
-
+- name: Set up version seperator
+  when: "pdns_package_version | length > 0"
+  block:
   - name: Prefix the PowerDNS version with the correct separator on RedHat
-    set_fact:
+    ansible.builtin.set_fact:
       _pdns_package_version: "-{{ pdns_package_version }}"
     when: ansible_os_family == 'RedHat'
 
   - name: Prefix the PowerDNS version with the correct separator on Debian
-    set_fact:
+    ansible.builtin.set_fact:
       _pdns_package_version: "={{ pdns_package_version }}"
     when: ansible_os_family == 'Debian'
 
-  when: "pdns_package_version | length > 0"
-
 - name: Install PowerDNS
-  package:
+  ansible.builtin.package:
     name: "{{ pdns_package_name }}{{ _pdns_package_version | default('') }}"
     state: present
 
 - name: Install PowerDNS debug symbols
-  package:
+  ansible.builtin.package:
     name: "{{ pdns_debug_symbols_package_name }}{{ _pdns_package_version | default('') }}"
     state: present
   when: pdns_install_debug_symbols_package
 
 - name: Install PowerDNS backends
-  package:
+  ansible.builtin.package:
     name: "{{ pdns_backends_packages[item.key.split(':')[0]] }}{{ _pdns_package_version | default('') }}"
     state: present
   no_log: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Include OS-specific variables
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_distribution }}.yml"
@@ -10,46 +10,54 @@
   tags:
     - always
 
-- include_tasks: "repo-{{ ansible_os_family }}.yml"
+- name: Setup repository
+  ansible.builtin.include_tasks: "repo-{{ ansible_os_family }}.yml"
   when: "pdns_install_repo | length > 0"
   tags:
     - install
     - repository
 
-- include_tasks: install.yml
+- name: Install PowerDNS
+  ansible.builtin.include_tasks: install.yml
   tags:
     - install
 
-- include_tasks: inspect.yml
+- name: Get version of PowerDNS instance
+  ansible.builtin.include_tasks: inspect.yml
   tags:
     - db
     - mysql
     - sqlite
     - config
 
-- include_tasks: database-mysql.yml
+- name: Install and configure MySQL database
+  ansible.builtin.include_tasks: database-mysql.yml
   when: "pdns_mysql_databases_credentials | length > 0"
   tags:
     - db
     - mysql
 
-- include_tasks: database-sqlite3.yml
+- name: Install and configure SQlite database
+  ansible.builtin.include_tasks: database-sqlite3.yml
   when: "pdns_sqlite_databases_locations | length > 0"
   tags:
     - db
     - sqlite
 
-- include_tasks: database-lmdb.yml
+- name: Install and configure LMDB database
+  ansible.builtin.include_tasks: database-lmdb.yml
   when: "pdns_lmdb_databases_locations | length > 0"
   tags:
     - db
     - lmdb
 
-- include_tasks: configure.yml
+- name: Build config file
+  ansible.builtin.include_tasks: configure.yml
   tags:
     - config
 
-- include_tasks: selinux.yml
+- name: Configure SELinux
+  ansible.builtin.include_tasks: selinux.yml
   when: ansible_selinux is defined and ansible_selinux.status == 'enabled'
   tags:
     - selinux
@@ -57,7 +65,7 @@
 
 - name: Start and enable the PowerDNS service
   throttle: 1
-  service:
+  ansible.builtin.service:
     name: "{{ pdns_service_name }}"
     state: "{{ pdns_service_state }}"
     enabled: "{{ pdns_service_enabled }}"

--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -1,12 +1,11 @@
 ---
-
 - name: Install gnupg
-  package:
+  ansible.builtin.package:
     name: gnupg
     state: present
 
 - name: Import the PowerDNS APT Repository key from URL
-  apt_key:
+  ansible.builtin.apt_key:
     url: "{{ pdns_install_repo['gpg_key'] }}"
     id: "{{ pdns_install_repo['gpg_key_id'] | default('') }}"
     state: present
@@ -14,27 +13,27 @@
   register: _pdns_apt_key
 
 - name: Import the PowerDNS APT Repository key from File
-  apt_key:
-    data: "{{ lookup('file',  pdns_install_repo['gpg_key']) }}"
+  ansible.builtin.apt_key:
+    data: "{{ lookup('file', pdns_install_repo['gpg_key']) }}"
     id: "{{ pdns_install_repo['gpg_key_id'] | default('') }}"
     state: present
   when: not pdns_install_repo['gpg_key'] is regex("^[a-z]{3,}://")
   register: _pdns_apt_key
 
 - name: Add the PowerDNS APT Repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     filename: "{{ pdns_install_repo['name'] }}"
     repo: "{{ pdns_install_repo['apt_repo'] }}"
     state: present
   register: _pdns_apt_repo
 
 - name: Update the APT cache
-  apt:
+  ansible.builtin.apt:
     update_cache: yes
   when: "_pdns_apt_key.changed or _pdns_apt_repo.changed"
 
 - name: Pin the PowerDNS APT Repository
-  template:
+  ansible.builtin.template:
     src: pdns.pin.j2
     dest: /etc/apt/preferences.d/pdns
     owner: root

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -1,31 +1,29 @@
 ---
-
-- block:
-
+- name: Set up EPEL
+  when: pdns_install_epel
+  block:
   - name: Install epel-release on CentOS
-    yum:
+    ansible.builtin.package:
       name: epel-release
       state: present
     when: ansible_distribution in [ 'CentOS', 'Rocky', 'AlmaLinux' ]
 
   - name: Install epel-release on RHEL
-    package:
+    ansible.builtin.package:
       name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
       state: present
     when: ansible_distribution in [ 'RedHat' ]
 
   - name: Install epel-release and hostname on OracleLinux
-    package:
+    ansible.builtin.package:
       name: 
       - "oracle-epel-release-el{{ ansible_distribution_major_version }}"
       - hostname
       state: present
     when: ansible_distribution in [ 'OracleLinux' ]
 
-  when: pdns_install_epel
-
 - name: Install yum-plugin-priorities
-  package:
+  ansible.builtin.package:
     name: yum-plugin-priorities
     state: present
   when:
@@ -33,7 +31,7 @@
     - ansible_distribution_major_version | int < 8
 
 - name: Add the PowerDNS YUM Repository
-  yum_repository:
+  ansible.builtin.yum_repository:
     name: "{{ pdns_install_repo['name'] }}"
     file: "{{ pdns_install_repo['name'] }}"
     description: PowerDNS Authoritative Server
@@ -44,7 +42,7 @@
     state: present
 
 - name: Add the PowerDNS debug symbols YUM Repository
-  yum_repository:
+  ansible.builtin.yum_repository:
     name: "{{ pdns_install_repo['name'] }}-debuginfo"
     file: "{{ pdns_install_repo['name'] }}"
     description: PowerDNS Authoritative Server - debug symbols

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,13 +1,13 @@
 ---
-- name: allow mysql connect from pdns in selinux
-  seboolean:
+- name: Allow mysql connect from pdns in selinux
+  ansible.posix.seboolean:
     name: pdns_can_network_connect_db
     state: yes
     persistent: yes
   when: "pdns_mysql_databases_credentials | length > 0"
 
-- name: allow pdns to bind to udp high ports
-  seport:
+- name: Allow pdns to bind to udp high ports
+  community.general.seport:
     ports: 10000-20000
     proto: udp
     setype: dns_port_t

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
-ansible-lint==6.18.0
-yamllint==1.32.0
-molecule-plugins[docker]==23.4.1
-molecule-plugins[lint]==23.4.1
-molecule==5.1.0
-pytest-testinfra==8.1.0
+ansible-lint==24.12.2
+yamllint==1.35.1
+molecule-plugins[docker]==23.6.0
+molecule-plugins[lint]==23.6.0
+molecule==24.9.0
+pytest-testinfra==10.1.1
 docker==7.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 ansible-lint==24.12.2
+ansible-compat==24.10.0
 yamllint==1.35.1
 molecule-plugins[docker]==23.6.0
 molecule-plugins[lint]==23.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
 minversion = 1.8
-envlist = ansible{212,213,214}
+envlist = ansible{214,215,216}
 skipsdist = true
 
 [gh-actions:env]
 ANSIBLE=
-  2.12: ansible212
-  2.13: ansible213
   2.14: ansible214
+  2.15: ansible215
+  2.16: ansible216
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible212: ansible-core>2.12,<2.13
-    ansible213: ansible-core>2.13,<2.14
     ansible214: ansible-core>2.14,<2.15
+    ansible215: ansible-core>2.15,<2.16
+    ansible216: ansible-core>2.16,<2.17
 setenv =
   PY_COLORS = 1
 commands =


### PR DESCRIPTION
Tests now run against `ansible-core 2.14, 2.15 and 2.16`.

Added linter to CI workflow and fixed some lint issues