### PR TITLE
GH Actions: remove EOL Ubuntu 20.04 from molecule tests

### DIFF
--- a/molecule/pdns-47/molecule.yml
+++ b/molecule/pdns-47/molecule.yml
@@ -77,6 +77,7 @@ provisioner:
   options:
     diff: True
     v: True
+    forks: '1'
   config_options:
     defaults:
       gathering: smart

--- a/molecule/pdns-47/molecule.yml
+++ b/molecule/pdns-47/molecule.yml
@@ -40,14 +40,6 @@ platforms:
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
 
-  - name: ubuntu-2004
-    groups: ["pdns"]
-    image: ubuntu:20.04
-    tmpfs:
-      - /run
-      - /tmp
-    dockerfile_tpl: debian-systemd
-
   - name: ubuntu-2204
     groups: ["pdns"]
     image: ubuntu:22.04

--- a/molecule/pdns-48/molecule.yml
+++ b/molecule/pdns-48/molecule.yml
@@ -40,14 +40,6 @@ platforms:
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
 
-  - name: ubuntu-2004
-    groups: ["pdns"]
-    image: ubuntu:20.04
-    tmpfs:
-      - /run
-      - /tmp
-    dockerfile_tpl: debian-systemd
-
   - name: ubuntu-2204
     groups: ["pdns"]
     image: ubuntu:22.04

--- a/molecule/pdns-48/molecule.yml
+++ b/molecule/pdns-48/molecule.yml
@@ -90,6 +90,7 @@ provisioner:
   options:
     diff: True
     v: True
+    forks: '1'
   config_options:
     defaults:
       gathering: smart

--- a/molecule/pdns-49/molecule.yml
+++ b/molecule/pdns-49/molecule.yml
@@ -40,14 +40,6 @@ platforms:
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
 
-  - name: ubuntu-2004
-    groups: ["pdns"]
-    image: ubuntu:20.04
-    tmpfs:
-      - /run
-      - /tmp
-    dockerfile_tpl: debian-systemd
-
   - name: ubuntu-2204
     groups: ["pdns"]
     image: ubuntu:22.04

--- a/molecule/pdns-49/molecule.yml
+++ b/molecule/pdns-49/molecule.yml
@@ -98,6 +98,7 @@ provisioner:
   options:
     diff: True
     v: True
+    forks: '1'
   config_options:
     defaults:
       gathering: smart

--- a/molecule/pdns-master/molecule.yml
+++ b/molecule/pdns-master/molecule.yml
@@ -40,14 +40,6 @@ platforms:
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
 
-  - name: ubuntu-2004
-    groups: ["pdns"]
-    image: ubuntu:20.04
-    tmpfs:
-      - /run
-      - /tmp
-    dockerfile_tpl: debian-systemd
-
   - name: ubuntu-2204
     groups: ["pdns"]
     image: ubuntu:22.04

--- a/molecule/pdns-master/molecule.yml
+++ b/molecule/pdns-master/molecule.yml
@@ -98,6 +98,7 @@ provisioner:
   options:
     diff: True
     v: True
+    forks: '1'
   config_options:
     defaults:
       gathering: smart

--- a/molecule/pdns-os-repos/molecule.yml
+++ b/molecule/pdns-os-repos/molecule.yml
@@ -41,14 +41,6 @@ platforms:
     image: archlinux:base
     dockerfile_tpl: archlinux-systemd
 
-  - name: ubuntu-2004
-    groups: ["pdns"]
-    image: ubuntu:20.04
-    tmpfs:
-      - /run
-      - /tmp
-    dockerfile_tpl: debian-systemd
-
   - name: ubuntu-2204
     groups: ["pdns"]
     image: ubuntu:22.04

--- a/molecule/pdns-os-repos/molecule.yml
+++ b/molecule/pdns-os-repos/molecule.yml
@@ -73,6 +73,7 @@ provisioner:
   options:
     diff: True
     v: True
+    forks: '1'
   config_options:
     defaults:
       gathering: smart

--- a/molecule/systemd-no-overrides/molecule.yml
+++ b/molecule/systemd-no-overrides/molecule.yml
@@ -36,14 +36,6 @@ platforms:
     dockerfile_tpl: debian-systemd
     environment: { container: docker }
 
-  - name: ubuntu-2004
-    groups: ["pdns"]
-    image: ubuntu:20.04
-    tmpfs:
-      - /run
-      - /tmp
-    dockerfile_tpl: debian-systemd
-
   - name: ubuntu-2204
     groups: ["pdns"]
     image: ubuntu:22.04

--- a/molecule/systemd-no-overrides/molecule.yml
+++ b/molecule/systemd-no-overrides/molecule.yml
@@ -57,6 +57,7 @@ provisioner:
   options:
     diff: True
     v: True
+    forks: '1'
   config_options:
     defaults:
       gathering: smart


### PR DESCRIPTION
This PR removes Ubuntu 20.04 from the molecule tests. 

Packages from master are no longer built, which makes the [CI tests fail](https://github.com/PowerDNS/pdns-ansible/actions/runs/16701691361/job/47313504275#step:5:672)

In addition, CI tests occasionally fail when granting permissions in MySQL ([example](https://github.com/PowerDNS/pdns-ansible/actions/runs/16701691361/job/47313504252#step:5:541)). This PR sets the number of concurrent processes running tasks to `1`, increasing the duration of the workflow by ~3 minutes. This WO mitigates this behaviour.